### PR TITLE
Handle bus.end() without subscribers

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -498,6 +498,11 @@ describe "Bacon.Bus", ->
     bus.end()
     input.push("b")
     expect(events).toEqual([new Bacon.Next("a"), new Bacon.End()])
+
+  it "handles end() calls even when there are no subscribers", ->
+    bus = new Bacon.Bus()
+    bus.end()
+
   it "delivers pushed events and errors", ->
     expectStreamEvents(
       ->

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -575,7 +575,7 @@ class Bus extends EventStream
       sink new Error(error) if sink?
     @end = =>
       unsubAll()
-      sink end()
+      sink end() if sink?
 
 Bacon.EventStream = EventStream
 Bacon.Property = Property


### PR DESCRIPTION
The following code throws `TypeError: undefined is not a function`

```
Bacon = (require 'src/Bacon').Bacon
bus = new Bacon.Bus()
bus.end()
```

To fix this, I've added check for existence of `sink` like other methods in Bus.
