### PR TITLE
Generalize `scan` from EventStream to Property/EventStream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,26 @@ also use a property-extractor string instead of a function, as in
 `streamOrProperty.not()` returns a stream/property that inverts boolean
 values
 
+`streamOrProperty.scan(seed, f)` scans stream/property with given seed value and
+accumulator function, resulting to a Property. For example, you might
+use zero as seed and a "plus" function as the accumulator to create
+an "integral" property. Instead of a function, you can also supply a
+method name such as ".concat", in which case this method is called on
+the accumulator value and the new stream value is used as argument.
+
+Example:
+
+    var plus = function (a,b) { return a + b }
+    Bacon.sequentially(1, [1,2,3]).scan(0, plus)
+
+This would result to following elements in the result stream:
+
+    seed value = 0
+    0 + 1 = 1
+    1 + 2 = 3
+    3 + 3 = 6
+
+
 
 EventStream
 -----------
@@ -172,25 +192,6 @@ event stream. Function will receive Event objects (see below).
 The subscribe() call returns a `unsubscribe` function that you can
 call to unsubscribe. You can also unsubscribe by returning
 `Bacon.noMore` from the handler function as a reply to an Event.
-
-`stream.scan(seed, f)` scans stream with given seed value and
-accumulator function, resulting to a Property. For example, you might
-use zero as seed and a "plus" function as the accumulator to create
-an "integral" property. Instead of a function, you can also supply a
-method name such as ".concat", in which case this method is called on
-the accumulator value and the new stream value is used as argument.
-
-Example:
-
-    var plus = function (a,b) { return a + b }
-    Bacon.sequentially(1, [1,2,3]).scan(0, plus)
-
-This would result to following elements in the result stream:
-
-    seed value = 0
-    0 + 1 = 1
-    1 + 2 = 3
-    3 + 3 = 6
 
 `stream.skipDuplicates()` drops consecutive equal elements. So,
 from [1, 2, 2, 1] you'd get [1, 2, 1]. Uses === operator for equality

--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -631,6 +631,19 @@ describe "Property.assign", ->
     Bacon.constant("kaboom").assign(target, "pow", "smack", "whack")
     target.verify().pow("smack", "whack", "kaboom")
 
+describe "Property.scan", ->
+  it "yields the initial result immediately", ->
+    outputs = []
+    bus = new Bacon.Bus()
+    bus.toProperty(42).scan(1, (a, b) -> a + b).onValue((value) -> outputs.push(value))
+    expect(outputs).toEqual([43])
+  it "accumulates changes", ->
+    outputs = []
+    bus = new Bacon.Bus()
+    bus.toProperty(42).scan(1, (a, b) -> a + b).onValue((value) -> outputs.push(value))
+    bus.push(2)
+    expect(outputs).toEqual([43, 45])
+
 describe "Bacon.Bus", ->
   it "merges plugged-in streams", ->
     bus = new Bacon.Bus()

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -262,6 +262,19 @@ class Observable
     f = makeFunction(f, args)
     @withHandler (event) -> 
       @push event.fmap(f)
+  scan: (seed, f) ->
+    subject = @
+    f = toCombinator(f)
+    acc = seed
+    handleEvent = (event) ->
+      acc = f(acc, event.value) if event.hasValue()
+      @push event.apply(acc)
+    d = new Dispatcher(@subscribe, handleEvent)
+    subscribe = (sink) ->
+      reply = sink initial(acc) if acc? and !(subject.changes?)
+      d.subscribe(sink) unless reply == Bacon.noMore
+    new Property(subscribe)
+
   mapError : (f, args...) ->
     f = makeFunction(f, args)
     @withHandler (event) ->
@@ -448,18 +461,6 @@ class EventStream extends Observable
 
   toProperty: (initValue) ->
    @scan(initValue, latter)
-
-  scan: (seed, f) -> 
-    f = toCombinator(f)
-    acc = seed
-    handleEvent = (event) -> 
-      acc = f(acc, event.value) if event.hasValue()
-      @push event.apply(acc)
-    d = new Dispatcher(@subscribe, handleEvent)
-    subscribe = (sink) ->
-      reply = sink initial(acc) if acc?
-      d.subscribe(sink) unless reply == Bacon.noMore
-    new Property(subscribe)
 
   concat: (right) ->
     left = this


### PR DESCRIPTION
This lets us accumulate changes over a property's value. A common use case is to know what the current and previous values of a given property are to facilitate animations between states.

The semantics of this seem pretty clear to me. The only conceptually fuzzy bit is
not having the initial accumulator value in the stream; since a Property has an initial value,
and the semantics of a Property imply that previous values aren't so important, it seems we should ignore it.
