### PR TITLE
Fix combined property unsubscribe for initial value and error callbacks

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -452,6 +452,18 @@ describe "Property.combine", ->
         left.combine(right, (l, r)-> [l, r])
       [[null, null]])
 
+  it "unsubscribes when initial value callback returns Bacon.noMore", ->
+    calls = 0
+    bus = new Bacon.Bus()
+    other = Bacon.constant(["rolfcopter"])
+    bus.toProperty(["lollerskates"]).combine(other, ".concat").subscribe (e) ->
+      if !e.isInitial()
+        calls += 1
+      Bacon.noMore
+
+    bus.push(["fail whale"])
+    expect(calls).toBe 0
+
 describe "Bacon.combineAsArray", -> 
   it "combines properties and latest values of streams, into a Property having arrays as values", ->
     expectPropertyEvents(

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -548,7 +548,7 @@ class Property extends Observable
               Bacon.noMore
             else if event.isError()
                 reply = sink event
-                unsubBoth if reply == Bacon.noMore
+                unsubBoth() if reply == Bacon.noMore
                 reply
             else
               setValue(new Some(event.value))
@@ -559,7 +559,7 @@ class Property extends Observable
                 else
                   initialSent = true
                   reply = thisSink(sink, event, myVal.value, otherVal.value)
-                  unsubBoth if reply == Bacon.noMore
+                  unsubBoth() if reply == Bacon.noMore
                   reply
               else
                 Bacon.more


### PR DESCRIPTION
There were some no-operations in Property combination code. It seems like unsubscribe is not run when either initial value or error callback returns `Bacon.noMore`.
