### PR TITLE
Allow .fromEventTarget to define a custom mapping function

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ would lead to 1,2,3,1,2,3... to be repeated indefinitely.
 `Bacon.never()` creates an EventStream that immediately ends.
 
 `Bacon.fromEventTarget(target, event)` creates an EventStream from events
-on a DOM EventTarget or Node.JS EventEmitter object.
+on a DOM EventTarget or Node.JS EventEmitter object. You can also pass an optional function that processes the emitted 
+events' parameters.
 
 `Bacon.fromPoll(interval, f)` polls given function with given interval.
 Function should return Events: either Next or End.

--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -74,6 +74,18 @@ describe "Bacon.fromEventTarget", ->
       ["x"]
     )
 
+  it "should allow a custom map function for EventStream from EventEmitter", ->
+    emitter = new EventEmitter()
+    emitter.on "newListener", ->
+      runs ->
+        emitter.emit "data", "x", "y"
+
+    expectStreamEvents(
+      -> Bacon.fromEventTarget(emitter, "data", (x, y) => [x, y]).take(1)
+      [["x", "y"]]
+    )
+
+
   it "should clean up event listeners from EventEmitter", ->
     emitter = new EventEmitter()
     Bacon.fromEventTarget(emitter, "data").take(1).subscribe ->

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -87,10 +87,10 @@ Bacon.fromPoll = (delay, poll) ->
 #   # => EventStream
 #
 # Returns EventStream
-Bacon.fromEventTarget = (target, eventName) ->
+Bacon.fromEventTarget = (target, eventName, eventTransformer = _.id) ->
   new EventStream (sink) ->
-    handler = (event) ->
-      reply = sink (next event)
+    handler = (args...) ->
+      reply = sink (next eventTransformer args...)
       if reply == Bacon.noMore
         unbind()
 


### PR DESCRIPTION
The motivation for this change stems from NodeJS EventEmitters allowing emission of multiple arguments to a callback. Currently bacon.js only emits the first of these callback arguments to the stream, and others are lost.

Example:

```
var ee = new (require('events').EventEmitter);

ee.on("event", function() { console.log(Array.prototype.slice.call(arguments)); });
ee.emit("event", "foo", "bar"); // [ 'foo', 'bar' ]

// whereas

Bacon.fromEventTarget(ee, "event").log();
ee.emit("event", "foo", "bar"); // 'foo'
```

With this change you can do:

```
Bacon.fromEventTarget(ee, "event", function() { return Array.prototype.slice.call(arguments); }).log();
ee.emit("event", "foo", "bar"); // ['foo', 'bar']
```
