### PR TITLE
Update fromPromise to match other from* functions

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -15,7 +15,7 @@
 Bacon = @Bacon = {}
 
 Bacon.fromPromise = (promise) ->
-  new Bacon.EventStream(
+  new EventStream(
     (sink) ->
       onSuccess = (value) ->
         sink next(value)


### PR DESCRIPTION
This is very minor, but I was looking through the code and noticed that fromPromise was not using the next and end functions (to create Next and End objects) that every other from\* function uses, and it also used Bacon.EventStream instead of just EventStream. So I updated fromPromise to match the other from\* functions.
