### PR TITLE
Use subscriber return values that won't cause collisions

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -27,9 +27,9 @@ Bacon.fromPromise = (promise) ->
       nop
   )
 
-Bacon.noMore = "veggies"
+Bacon.noMore = ["<no-more>"]
 
-Bacon.more = "moar bacon!"
+Bacon.more = ["<more>"]
 
 Bacon.later = (delay, value) ->
   Bacon.sequentially(delay, [value])


### PR DESCRIPTION
Currently `Bacon.more` and `Bacon.noMore` are just strings, which could cause problems as the use of return values in subscribers is not enforced. If there is a subscriber that returns accidentally `"veggies"`, the subscriber would end. This is not that hard to achieve if you're using coffeescript and handling user input.

I've changed the return values to be arrays, which won't match to === unless same pointer is used.

``` javascript
"foo" === "foo"
// => true
["foo"] === ["foo"]
// => false
```
