### PR TITLE
Undefined as first value of Observable.skipDuplicates() is skipped

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -224,6 +224,12 @@ describe "EventStream.skipDuplicates", ->
     expectStreamEvents(
       -> series(1, [1, 2, error(), 2, 3, 1]).skipDuplicates()
     [1, 2, error(), 3, 1])
+
+  it "allows undefined as initial value", ->
+    expectStreamEvents(
+      -> series(1, [undefined, undefined, 1, 2]).skipDuplicates()
+    [undefined, 1, 2])
+
   it "works with custom isEqual function", ->
     a = {x: 1}; b = {x: 2}; c = {x: 2}; d = {x: 3}; e = {x: 1}
     isEqual = (a, b) -> a?.x == b?.x

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -337,11 +337,11 @@ class Observable
         @push event
   distinctUntilChanged: -> @skipDuplicates()
   skipDuplicates: (isEqual = (a, b) -> a is b) ->
-    @withStateMachine undefined, (prev, event) ->
+    @withStateMachine None, (prev, event) ->
       if !event.hasValue()
         [prev, [event]]
-      else if not isEqual(prev, event.value())
-        [event.value(), [event]]
+      else if prev == None or not isEqual(prev.get(), event.value())
+        [new Some(event.value()), [event]]
       else
         [prev, []]
   withStateMachine: (initState, f) ->


### PR DESCRIPTION
When using skipDuplicates, `undefined` is used to mark initial previous value of streams. This works fine unless `undefined` is actually emitted to stream.

``` coffee-script
Bacon.once(undefined).skipDuplicates()
# => expected: undefined, result: no events
```

This PR also causes the first comparison to be skipped when custom isEqual function is used, which changes the semantics slightly, but can be useful if your comparison function looks like

``` coffee-script
(a, b) -> a.x == b.x
```
