### PR TITLE
node.js example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,7 +863,7 @@ Sure. Works. Try it out.
 
 Then type `node` and try the following
 
-    Bacon = require("baconjs").bacon()
+    Bacon = require("baconjs").Bacon
     Bacon.sequentially(1000, ["B", "A", "C", "O", "N"]).log()
 
 Why Bacon?


### PR DESCRIPTION
The readme example with require("baconjs").bacon() does not work. This works:

```
Bacon = require("baconjs").Bacon
Bacon.sequentially(1000, ["B", "A", "C", "O", "N"]).log()
```
