### PR TITLE
Bacon.asEventStream

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -14,7 +14,7 @@ Bacon.asEventStream = (eventName, selector, eventTransformer = _.id) ->
     element.on(eventName, selector, handler)
     unbind
 
-# `this isnt window` in broserified environment
+# `this isnt window` in browserified environment
 if window?
   (window.jQuery || window.Zepto)?.fn.asEventStream = Bacon.asEventStream
 


### PR DESCRIPTION
Addressing https://github.com/raimohanska/bacon.js/commit/69dfbd118ae5773bf5cb0c16ce6897783d11d7d8#commitcomment-2771960
Exports `.asEventStream` for those who need it in Node.
