### PR TITLE
Fix sampledBy with stream of functions

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -1187,6 +1187,13 @@ describe "Property.sampledBy(stream)", ->
         p = series(5, [1, 2]).toProperty()
         p.sampledBy(series(3, [0, 0, 0, 0]).toProperty())
       [1, 1, 2])
+  describe "works with stream of functions", ->
+    f = ->
+    expectStreamEvents(
+      ->
+        p = series(1, [f]).toProperty()
+        p.sampledBy(series(1, [1, 2, 3]))
+      [f, f, f])
 
 describe "Property.sampledBy(property)", ->
   describe "samples property at events, resulting to a Property", ->

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -686,7 +686,7 @@ class Property extends Observable
         unsubOther = sampler.subscribe (event) =>
           if event.hasValue()
             myVal.forEach (myVal) =>
-              sink(event.apply(lazyCombinator(myVal, event)))
+              sink(event.apply(-> lazyCombinator(myVal, event)))
           else
             if event.isEnd()
               unsubMe()


### PR DESCRIPTION
The problem is `Bacon.constant(function() { return 10; }).sampledBy(Bacon.once(1)).log()` logs 10 while `Bacon.constant(function() { return 10; }).log()` logs function.
