### PR TITLE
takeWhile(false) returns Bacon.never()

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -308,6 +308,7 @@ class Observable
         else
           Bacon.more
   takeWhile: (f, args...) ->
+    return Bacon.never() if not f
     convertArgsToFunction this, f, args, (f) ->
       @withHandler (event) ->
         if event.filter(f)


### PR DESCRIPTION
Fix #223 takeWhile returns Bacon.never() on falsey values.
