### PR TITLE
Combine as array simplify

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -155,7 +155,8 @@ Bacon.combineAsArray = (streams, more...) ->
     streams = [streams].concat(more)
   for stream, index in streams
     streams[index] = Bacon.constant(stream) if not (stream instanceof Observable)
-  if streams.length
+  n = streams.length
+  if n
     values = (None for s in streams)
     new Property (sink) =>
       ends = (false for s in streams)
@@ -168,9 +169,9 @@ Bacon.combineAsArray = (streams, more...) ->
           else if event.isError()
             reply = sink event
           else
+            n-- if values[index] == None
             values[index] = event.value
-            if sent or _.all(values, (x) -> x != None)
-              sent = true
+            if n == 0
               valueArrayF = -> (x() for x in values)
               reply = sink event.apply(valueArrayF)
           unsubAll() if reply == Bacon.noMore


### PR DESCRIPTION
Simplification of combineAsArray. Contains (AFAIK) two possible semantic changes.

1) For some reason combineAsArray currently stores functions which it evaluates. I can't think of a reason as to why this is the case, and I can't really see how the time of evaluation could affect anything here.

2) When one of the subscriptions produce an [end] event, but some other stream is still alive, it might get Bacon.more as a return value, instead of Bacon.noMore. Could this ever matter? The stream is ending anyway I mean?
