### PR TITLE
Fix testling CI to point at correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,7 +1350,7 @@ Automatically tested on each commit on modern browsers and IE6+.
 
 The full Bacon.js test suite is run on testling.ci with a wide range of browsers:
 
-[![browser support test report](http://ci.testling.com/raimohanska/bacon.js.png)](http://ci.testling.com/raimohanska/bacon.js)
+[![browser support test report](http://ci.testling.com/baconjs/bacon.js.png)](http://ci.testling.com/baconjs/bacon.js)
 
 Results from those tests are quite unreliable, producing random failures, but the bottom line is that there are no outstanding compatibility issues.
 


### PR DESCRIPTION
Current README.md still points to `raimohanska`. I assume this is the correct new address, and it seems to work.
