### PR TITLE
Remove raw.github.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ Install
 
 You can download the latest [generated javascript](https://raw.github.com/baconjs/bacon.js/master/dist/Bacon.js).
 
-..or you can use script tags to include this file directly from Github:
-
-```html
-<script src="https://rawgithub.com/baconjs/bacon.js/master/dist/Bacon.js"></script>
-```
-
 Version 0.6.8 can also be found from cdnjs hosting:
 
     http://cdnjs.cloudflare.com/ajax/libs/bacon.js/0.6.8/Bacon.js


### PR DESCRIPTION
The reason are well explained in rawgithub.com, but basically github sends (on purpose) the wrong headers, so resources can be wrongly/not interpreted by browsers. I'm not affiliated with rawgithub.com (which is a free service anyway) and I know it could die anytime, but it's still better that the GH raw thing which is good for downloading only.
