### PR TITLE
Add onDispose method

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,10 @@ currently awaiting an AJAX response:
 var showAjaxIndicator = ajaxRequest.awaiting(ajaxResponse)
 ```
 
+`observable.onDispose(f)` runs a function whenever an Observable is
+disposed or ended. You can use this function to clean up any resources
+that you've allocated in the process of creating an observable.
+
 `observable.endOnError` ends the Observable on first Error event. The
 error is included in the output of the returned Observable.
 

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -480,6 +480,15 @@ class Observable
   awaiting: (other) ->
     this.toEventStream().map(true).merge(other.toEventStream().map(false)).toProperty(false)
 
+  onDispose: (f) ->
+    f = Bacon._.cached f
+    @withSubscribe (sink) =>
+      unsub = @subscribe (e) ->
+        reply = sink(e)
+        if (e.isEnd() || reply == Bacon.noMore)
+          f();
+        reply
+      -> f(); unsub() 
 
 Observable :: reduce = Observable :: fold
 


### PR DESCRIPTION
A convenient method for cleaning up resources allocated when creating an Observable. I use this all the time, figured it's a candidate for core. I'll complement with tests if we want to include it.
