### PR TITLE
Insert version to dist files on release

### DIFF
--- a/release
+++ b/release
@@ -18,6 +18,7 @@ npm test
 
 echo "Updating files"
 sed -i "" 's/\("version".*:.*\)".*"/\1"'$version'"/' $files
+sed -i "" 's/<version>/'$version'/' dist/*.js
 
 echo "Commit and tag"
 git add .

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -1,5 +1,7 @@
 Bacon = {}
 
+Bacon.version = '<version>'
+
 # eventTransformer - should return one value or one or many events
 Bacon.fromBinder = (binder, eventTransformer = _.id) ->
   new EventStream (sink) ->


### PR DESCRIPTION
Related issue: #274 

It's quite common (if not de facto standard) to have the version in the
file so this is a Good Thing!

> ./release 1.2.3
> =>
> dist/Bacon.js:
> ...
> Bacon.version = '1.2.3';
> ...

Same for the minified file.
