### PR TITLE
add license header

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -1,3 +1,27 @@
+###! Bacon.js
+
+The MIT License
+
+Copyright (c) 2012 Juha Paananen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+###
 Bacon = {
   toString: -> "Bacon"
 }


### PR DESCRIPTION
It would be nice to have `Bacon.js` file with license included. MIT license requires its distribution with every copy of software [source], so this commit will satisfy license in circumstances of taking single `Bacon.js` file directly from GitHub and including it in combined/minimized file (like affter using of *r.js*, *almond* and *Uglify*).

`Bacon.min.js` could also include license (anyway, this license header comment could be easily stripped by user). I can send another PR for that if you're interested.
