### PR TITLE
Tests are run with locally installed coffee

### DIFF
--- a/release
+++ b/release
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 if [ -z $1 ]; then
   echo "usage: release <version>"

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 npm install --silent
 

--- a/version
+++ b/version
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash -e
+
 cat package.json|grep version|sed 's/.*:.*"\(.*\)".*/\1/'


### PR DESCRIPTION
This is good at least for two reasons:
- we can be certain that the tests are run with the `coffee` version specified in [package.json](https://github.com/mileskin/bacon.js/blob/9dccf55a19e7b9be27348af5addf9ac15a82f190/package.json#L22)
- tests can be run even if `coffee` is not installed globally

While at it, all shell scripts now use the same shebang line. See http://en.wikipedia.org/wiki/Shebang_(Unix)#Portability
