### PR TITLE
Do AMD detection first to work around conflict with AngularMocks

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -1470,10 +1470,10 @@ Bacon.scheduler =
   clearInterval: (id) -> clearInterval(id)
   now: -> new Date().getTime()
 
-if module?
+if define? and define.amd?  
+  define [], -> Bacon  
+else if module?
   module.exports = Bacon # for Bacon = require 'baconjs'
   Bacon.Bacon = Bacon # for {Bacon} = require 'baconjs'
 else
-  if define? and define.amd?
-    define [], -> Bacon
   @Bacon = Bacon # otherwise for execution context


### PR DESCRIPTION
AngularMocks is very naughty and defines a global function named "module". (https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L2021)

This conflicts with BaconJS's module loader detection, and tricks Bacon into thinking it's running inside a CommonJS context.

This makes it impossible to run unit tests in an AngularJS application when using Bacon.

This affects Bacon.Model as well.

The workaround is to detect AMD (RequireJS) modules first before looking for the existence of `module` on the global scope.

There are probably better solutions to this.
