### PR TITLE
use prototype to implement Desc

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -1071,6 +1071,16 @@ describe = (context, method, args...) ->
   else
     new Desc(context, method, args)
 
+findDeps = (x) ->
+  if isArray(x)
+    _.flatMap findDeps, x
+  else if isObservable(x)
+    [x]
+  else if x instanceof Source
+    [x.obs]
+  else
+    []
+
 class Desc
   constructor: (context, method, args) ->
     @context = context
@@ -1085,7 +1095,7 @@ class Desc
     return @flatDeps[b.id]
 
   apply: (obs) ->
-    deps = _.cached (=> @findDeps([@context].concat(@args)))
+    deps = _.cached (=> findDeps([@context].concat(@args)))
     obs.internalDeps = obs.internalDeps || deps
     obs.dependsOn = dependsOn.bind(@, obs)
     obs.deps = deps
@@ -1101,15 +1111,7 @@ class Desc
       @flatDeps[dep.id] = true
       @collectDeps(dep)
 
-  findDeps: (x) ->
-    if isArray(x)
-      _.flatMap @findDeps.bind(@), x
-    else if isObservable(x)
-      [x]
-    else if x instanceof Source
-      [x.obs]
-    else
-      []
+
 
 withDescription = (desc..., obs) ->
   describe(desc...).apply(obs)


### PR DESCRIPTION
The memory footprint is slightly smaller. With a simple test of bus chained with 50 `filter` on it, the retained size of single EventStream droppped from ~2k to ~1.6k.

Doesn't seem to affect performance at all:

```
desc-prototype % coffee performance/PerformanceTest.coffee
diamond x 21.99 ops/sec ±7.54% (41 runs sampled)
combo x 40.96 ops/sec ±6.72% (45 runs sampled)
zip x 1,611 ops/sec ±5.07% (80 runs sampled)
Bacon.combineTemplate.sample x 333 ops/sec ±4.58% (80 runs sampled)
Bacon.combineTemplate (deep) x 18.60 ops/sec ±4.34% (36 runs sampled)
Bacon.combineTemplate x 219 ops/sec ±3.53% (83 runs sampled)
EventStream.map x 3,263 ops/sec ±5.31% (80 runs sampled)
EventStream.scan x 2,951 ops/sec ±4.35% (77 runs sampled)
EventStream.toProperty x 3,087 ops/sec ±4.46% (81 runs sampled)

master % coffee performance/PerformanceTest.coffee
diamond x 21.84 ops/sec ±9.18% (40 runs sampled)
combo x 37.54 ops/sec ±12.23% (36 runs sampled)
zip x 1,487 ops/sec ±5.02% (77 runs sampled)
Bacon.combineTemplate.sample x 325 ops/sec ±4.75% (82 runs sampled)
Bacon.combineTemplate (deep) x 18.64 ops/sec ±4.01% (36 runs sampled)
Bacon.combineTemplate x 217 ops/sec ±5.20% (76 runs sampled)
EventStream.map x 3,013 ops/sec ±5.33% (80 runs sampled)
EventStream.scan x 3,038 ops/sec ±4.07% (80 runs sampled)
EventStream.toProperty x 2,832 ops/sec ±4.45% (80 runs sampled)
```
