### PR TITLE
Bacon.retry source function is called after the specified delay

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -2783,16 +2783,16 @@ describe "Bacon.retry", ->
           Bacon.once(new Bacon.Error({calls}))
         Bacon.retry {source, retries: 2}
       [error(calls: 3)]) # TODO: assert error content
-  it "allows specifying interval by context for each retry", (done) ->
+  it "allows specifying delay by context for each retry", (done) ->
     calls = 0
     contexts = []
     source = ->
       calls += 1
       Bacon.once(new Bacon.Error({calls}))
-    interval = (context) ->
+    delay = (context) ->
       contexts.push(context)
       1
-    Bacon.retry({source, interval, retries: 2}).onError (err) ->
+    Bacon.retry({source, delay, retries: 2}).onError (err) ->
       expect(contexts).to.deep.equal [
         {error: {calls: 1}, retriesDone: 0}
         {error: {calls: 2}, retriesDone: 1}

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -259,13 +259,13 @@ Bacon.retry = (options) ->
   source = options.source
   retries = options.retries || 0
   maxRetries = options.maxRetries || retries
-  interval = options.interval || -> 0
+  delay = options.delay || -> 0
   isRetryable = options.isRetryable || -> true
 
   retry = (context) ->
-    nextAttemptOptions = {source, retries: retries - 1, maxRetries, interval, isRetryable}
+    nextAttemptOptions = {source, retries: retries - 1, maxRetries, delay, isRetryable}
     delayedRetry = -> Bacon.retry(nextAttemptOptions)
-    Bacon.later(interval(context)).filter(false).concat(Bacon.once().flatMap(delayedRetry))
+    Bacon.later(delay(context)).filter(false).concat(Bacon.once().flatMap(delayedRetry))
 
   withDescription(Bacon, "retry", options, source().flatMapError (e) ->
     if isRetryable(e) && retries > 0


### PR DESCRIPTION
Previously the source function was called immediately after the first error which was quite nasty especially with an ajax source.

Also `interval` is renamed to `delay` since it's not really an interval but rather a retry specific, dynamic delay. I know this is not backwards compatible but `Bacon.retry` just landed to master so maybe we can still improve the API naming a bit :-P Furthermore, it's not even documented yet! Wait, I promised to deliver that...
