### PR TITLE
Update README zipAsArray example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,7 +1122,7 @@ y = Bacon.fromArray([10, 20, 30])
 z = Bacon.fromArray([100, 200, 300])
 Bacon.zipAsArray(x, y, z)
 
-# produces values 111, 222, 333
+# produces values [1, 10, 100], [2, 20, 200] and [3, 30, 300]
 ```
 
 <a name="bacon-zipasarray-multiple-streams"></a>

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1183,7 +1183,7 @@ y = Bacon.fromArray([10, 20, 30])
 z = Bacon.fromArray([100, 200, 300])
 Bacon.zipAsArray(x, y, z)
 
-# produces values 111, 222, 333
+# produces values [1, 10, 100], [2, 20, 200] and [3, 30, 300]
 ```
 """
 


### PR DESCRIPTION
I'm new to Bacon.js and was reading through the docs and came across [Bacon.zipAsArray](https://github.com/baconjs/bacon.js#bacon-zipasarray) function and its example: 

``` coffee
x = Bacon.fromArray([1,2,3])
y = Bacon.fromArray([10, 20, 30])
z = Bacon.fromArray([100, 200, 300])
Bacon.zipAsArray(x, y, z)

# produces values 111, 222, 333
```

The example seems to be misleading, and has wrong output. Correct me if I'm wrong, but what I think that this function produces (and I checked with `.log()`) is three values, arrays of `[1, 10, 100]`, `[2, 20, 200]` and `[3, 30, 300]`. Am I correct?
