### PR TITLE
Memory usage optimisations

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -3212,7 +3212,7 @@ describe "Observable.withDescription", ->
   it "affects toString and inspect", ->
     expect(Bacon.once(1).withDescription(Bacon, "una", "mas").inspect()).to.equal("Bacon.una(mas)")
   it "affects desc", ->
-    description = Bacon.once(1).withDescription(Bacon, "una", "mas").desc()
+    description = Bacon.once(1).withDescription(Bacon, "una", "mas").desc
     expect(description.context).to.equal(Bacon)
     expect(description.method).to.equal("una")
     expect(description.args).to.deep.equal(["mas"])

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -337,6 +337,7 @@ class Observable
   constructor: (desc) ->
     @id = ++idCounter
     withDescription(desc, this)
+    @initialDesc = @desc
   onValue: ->
     f = makeFunctionArgs(arguments)
     @subscribe (event) ->
@@ -576,10 +577,11 @@ class Observable
   toString: ->
     if @_name
       @_name
-    else if @desc
-      @desc().toString()
     else
-      _.toString(this)
+      @desc.toString()
+
+  internalDeps: ->
+    @initialDesc.deps()
 
 Observable :: reduce = Observable :: fold
 Observable :: assign = Observable :: onValue
@@ -1110,13 +1112,13 @@ findDeps = (x) ->
 
 class Desc
   constructor: (@context, @method, @args) ->
+    @cached = null
+
+  deps: ->
+    @cached ||= findDeps([@context].concat(@args))
 
   apply: (obs) ->
-    that = @
-
-    deps = _.cached (-> findDeps([that.context].concat(that.args)))
-    obs.internalDeps = obs.internalDeps || deps
-    obs.desc = -> that
+    obs.desc = @
     obs
 
   toString: ->


### PR DESCRIPTION
Drops unsubscribed EventStream memory footprint from 2.91KiB to 2.19KiB. The footprint is smaller than in 0.6.x. Performance seems to be improved too as there is less GC pressure.

The bulk of the performance gains seems to be from changing `Desc` to be a simple object and calling it from `Observable` when needed. No more are `dependsOn` and `toString` methods assigned in `Desc::apply` and `internalDeps` are fetched via the initial description object. There's a minor API change: observable.desc returns the `Desc` object directly instead of a plain JS object with similar properties.

Other minor gains were introduced by using prototype functions and using Array::shift instead of Array::splice to extract the first element of an array.

| Test | Master | This PR |
| --- | --- | --- |
| diamond | 33.77 ops/sec ±5.58% (39 runs sampled) | 40.64 ops/sec ±6.12% (44 runs sampled) |
| combo | 39.45 ops/sec ±4.79% (33 runs sampled) | 67.62 ops/sec ±6.11% (42 runs sampled) |
| zip | 2,438 ops/sec ±4.26% (81 runs sampled) | 2,635 ops/sec ±4.66% (82 runs sampled) |
| flatMap | 118 ops/sec ±5.13% (69 runs sampled) | 141 ops/sec ±5.07% (63 runs sampled) |
| Bacon.combineTemplate.sample | 480 ops/sec ±4.24% (79 runs sampled) | 511 ops/sec ±3.62% (84 runs sampled) |
| Bacon.combineTemplate (deep) | 27.63 ops/sec ±3.54% (51 runs sampled) | 28.59 ops/sec ±4.10% (53 runs sampled) |
| Bacon.combineTemplate | 359 ops/sec ±3.12% (79 runs sampled) | 384 ops/sec ±3.06% (81 runs sampled) |
| EventStream.map | 4,525 ops/sec ±4.17% (79 runs sampled) | 4,836 ops/sec ±4.16% (81 runs sampled) |
| EventStream.scan | 4,238 ops/sec ±4.11% (73 runs sampled) | 4,452 ops/sec ±4.46% (82 runs sampled) |
| EventStream.toProperty | 4,194 ops/sec ±4.12% (82 runs sampled) | 4,485 ops/sec ±4.31% (78 runs sampled) |
