### PR TITLE
Additional checking for testing environments

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -1605,8 +1605,8 @@ Bacon.scheduler =
 if define? and define.amd?
   define [], -> Bacon
   @Bacon = Bacon
-else if module?
-  module.exports = Bacon # for Bacon = require 'baconjs'
+else if module? and exports?
+  exports = Bacon # for Bacon = require 'baconjs'
   Bacon.Bacon = Bacon # for {Bacon} = require 'baconjs'
 else
   @Bacon = Bacon # otherwise for execution context


### PR DESCRIPTION
In some testing environments (angularjs mocks, Qunit), module is a global variable but is not the same as a commonjs module definition object (i.e. does not have module.exports). In such cases, this change adds additional checking for a global exports object as well. The combination of the two is a better inidication whether we are in a commonjs environment. 

Issue: #417 
