### PR TITLE
BUG: toString Date-test fails when run with negative timezone-offset

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -123,7 +123,7 @@ describe "Bacon._", ->
     it "for strings", ->
       expect(_.toString("lol")).to.equal("lol")
     it "for dates", ->
-      expect(_.toString(new Date(0))).to.contain("1970")
+      expect(_.toString(new Date((new Date(0)).getTimezoneOffset() * 60 * 1000))).to.contain("1970")
     it "for arrays", ->
       expect(_.toString([1,2,3])).to.equal("[1,2,3]")
     it "for objects", ->


### PR DESCRIPTION
The timezone-offset for a given user may result in the expression "new Date(0)" returning a date that, when stringified, will be in the format "Wed Dec 31, 1969 HH:MM:SS OFFSET TIMEZONE". The result of this behavior is that the test fails (deterministically) when run on machines whose timezone-offset is negative.

To work around this, factor in the user's timezone-offset when instantiating the test date.
