### PR TITLE
Fix Bacon.fromArray(...).toString() output after subscription

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -160,15 +160,16 @@ Bacon.once = (value) -> withDescription(Bacon, "once", value, Bacon.fromArray([v
 Bacon.fromArray = (values) ->
   assertArray values
   values = cloneArray(values)
+  i = 0
   new EventStream describe(Bacon, "fromArray", values), (sink) ->
     unsubd = false
     reply = Bacon.more
     while (reply != Bacon.noMore) and !unsubd
-      if _.empty values
+      if i >= values.length
         sink(end())
         reply = Bacon.noMore
       else
-        value = values.shift()
+        value = values[i++]
         reply = sink(toEvent(value))
     -> unsubd = true
 


### PR DESCRIPTION
``` coffee
stream = Bacon.fromArray [1, 2, 3]
console.log stream.toString() # Bacon.fromArray([1,2,3])
stream.subscribe (->)
console.log stream.toString() # Bacon.fromArray([])
```

Another solution was to pass the second clone of `values` into `describe`, but I don't like unnecessary copying, especially when there is a really simple alternative.
