### PR TITLE
Fix live examples link

### DIFF
--- a/examples/examples.html
+++ b/examples/examples.html
@@ -1,6 +1,6 @@
 <!--
   To view these examples live, visit:
-  http://htmlpreview.github.io/?https://raw.github.com/baconjs/bacon.js/master/examples/examples.html
+  http://htmlpreview.github.io/?https://rawgit.com/baconjs/bacon.js/master/examples/examples.html
  -->
 <html>
   <head>


### PR DESCRIPTION
Hotlinking to raw.github.com (or raw.githubusercontent.com) no longer works in major browsers since they started [respecting Github's use of `X-Content-Type-Options: nosniff`](https://github.com/blog/1482-).

RawGit to the rescue.
