### PR TITLE
check for module.exports for nodejs environent.

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -1624,7 +1624,7 @@ Bacon.scheduler = {
 if define? and define.amd?
   define [], -> Bacon
   @Bacon = Bacon
-else if module and module.exports?
+else if module? and module.exports?
   module.exports = Bacon # for Bacon = require 'baconjs'
   Bacon.Bacon = Bacon # for {Bacon} = require 'baconjs'
 else


### PR DESCRIPTION
checking for module.exports checks more thoroughly that it is in fact nodejs.  Bugs occur in environments when module exists (angular-mocks specifically).
