### PR TITLE
More reliable memory test results

### DIFF
--- a/performance/MemoryTest.coffee
+++ b/performance/MemoryTest.coffee
@@ -35,8 +35,8 @@ stddev = (xs) ->
 processResults = (results, i) ->
   values = (x[i] for x in results)
 
-  mean: mean(values)
-  stddev: stddev(values)
+  mean: mean(values[2..])
+  stddev: stddev(values[2..])
 
 printResult = (label, result, forcePrefix = false) ->
   prefix = if prefix && result.mean > 0 then '+' else ''


### PR DESCRIPTION
Ignore results from first iterations to ensure that at least some code is properly compiled before running benchmarks. This eliminates large error ranges in basic event stream case. Results are now also in line with what is published in [Kefir repo](https://github.com/pozadi/kefir/blob/master/test/perf/memory-results.txt).
