### PR TITLE
Dispatcher tuning

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -918,7 +918,7 @@ class Dispatcher
     @pushing = false
     @ended = false
     @prevError = undefined
-    @unsubscribeFromSource = nop
+    @unsubSrc = undefined
 
   hasSubscribers: ->
     @subscriptions.length > 0
@@ -966,6 +966,10 @@ class Dispatcher
     else
       @push event
 
+  unsubscribeFromSource: ->
+    @unsubSrc() if @unsubSrc
+    @unsubSrc = undefined
+
   subscribe: (sink) =>
     if @ended
       sink end()
@@ -975,11 +979,8 @@ class Dispatcher
       subscription = { sink: sink }
       @subscriptions.push(subscription)
       if @subscriptions.length == 1
-        unsubSrc = @_subscribe @handleEvent
-        @unsubscribeFromSource = ->
-          unsubSrc()
-          @unsubscribeFromSource = nop
-      assertFunction @unsubscribeFromSource
+        @unsubSrc = @_subscribe @handleEvent
+        assertFunction @unsubSrc
       =>
         @removeSub subscription
         @unsubscribeFromSource() unless @hasSubscribers()


### PR DESCRIPTION
In #450, there was a regression in Node.js benchmarks. This was caused by initialising new function for `unsubscribeFromSource` value. Here the logic is moved to prototype and only the return value of `@_subscribe` is stored to the instance. This brings Node.js benchmarks for flatMap back to what they were before and also reduces memory use of a subscribed stream by 0.49KiB.
