### PR TITLE
Implement Observable.partition

### DIFF
--- a/spec/BaconSpec.coffee
+++ b/spec/BaconSpec.coffee
@@ -3004,6 +3004,18 @@ describe "Observable.onEnd", ->
     s.end()
     expect(ended).to.deep.equal(true)
 
+describe "Observable.partition", ->
+  it "splits events to 2 separate streams", ->
+    b = new Bacon.Bus()
+    [even, odd] = b.partition((x)->x%2==0)
+    evenValues = []
+    oddValues = []
+    even.onValue (x) -> evenValues.push x 
+    odd.onValue (x) -> oddValues.push x
+    [1,2,3,4,5].forEach (x) -> b.push(x) 
+    expect(oddValues).to.deep.equal([1,3,5])
+    expect(evenValues).to.deep.equal([2,4])
+
 describe "Field value extraction", ->
   describe "extracts field value", ->
     expectStreamEvents(

--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -604,6 +604,10 @@ class Observable
 
   decode: (cases) -> withDescription(this, "decode", cases, @combine(Bacon.combineTemplate(cases), (key, values) -> values[key]))
 
+  partition: (f, args...) ->
+    convertArgsToFunction this, f, args, (f) ->
+      withDescription(this, "partition", f, [this.filter(f), this.filter(_.negate(f)) ])
+
   awaiting: (other) ->
     withDescription(this, "awaiting", other,
       Bacon.groupSimultaneous(this, other)


### PR DESCRIPTION
Implemented functionality to split a stream into 2 separate streams based on a boolean function.

Known issue: weird functionality with synchronous streams, same as adding to separate filters to a synchronous stream: the one that gets a subscriber will eat all the values, even the ones that should go into the other stream. Is this ok, or is there a way to fix the problem?
