### PR TITLE
Remove typo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ when there are subscribers to the stream. Polling ends permanently when
 <a name="bacon-once"></a>
 [`Bacon.once(value)`](#bacon-once "Bacon.once(value : Event[A] | A) : EventStream[A]") creates an EventStream that delivers the given
 single value for the first subscriber. The stream will end immediately
-after this value. You can also send send an [`Bacon.Error`](#bacon-error) event instead of a
+after this value. You can also send an [`Bacon.Error`](#bacon-error) event instead of a
 value: `Bacon.once(new Bacon.Error("fail"))`.
 
 <a name="bacon-fromarray"></a>

--- a/readme.coffee
+++ b/readme.coffee
@@ -237,7 +237,7 @@ when there are subscribers to the stream. Polling ends permanently when
 doc.fn "Bacon.once(value : Event[A] | A) : EventStream[A]", """
 creates an EventStream that delivers the given
 single value for the first subscriber. The stream will end immediately
-after this value. You can also send send an `Bacon.Error` event instead of a
+after this value. You can also send an `Bacon.Error` event instead of a
 value: `Bacon.once(new Bacon.Error("fail"))`.
 """
 


### PR DESCRIPTION
This PR removes a duplicate _send_ word from the README.
