### PR TITLE
Bacon.retry example using number for delay instead of function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,7 +1389,7 @@ ajaxResult = source.flatMap(function(url) {
         // function to call when trying, should return an EventStream
         source: function() { return ajaxCall(url) },
         retries: 5, // nr of times to retry before giving up
-        delay: 100 // delay in ms between retries
+        delay: function() { return 100; } // delay in ms between retries
     })
 })
 ```

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1454,7 +1454,7 @@ ajaxResult = source.flatMap(function(url) {
         // function to call when trying, should return an EventStream
         source: function() { return ajaxCall(url) },
         retries: 5, // nr of times to retry before giving up
-        delay: 100 // delay in ms between retries
+        delay: function() { return 100; } // delay in ms between retries
     })
 })
 ```


### PR DESCRIPTION
Bacon.retry's delay property takes a function that returns an integer. The documentation is incorrectly showing a integer being passed in.
