### PR TITLE
End Bacon.fromPromise() handler chains with .done() if present

### DIFF
--- a/src/Bacon.coffee
+++ b/src/Bacon.coffee
@@ -68,7 +68,7 @@ Bacon.fromEventTarget = (target, eventName, eventTransformer) ->
 
 Bacon.fromPromise = (promise, abort) ->
   withDescription(Bacon, "fromPromise", promise, Bacon.fromBinder (handler) ->
-    promise.then(handler, (e) -> handler(new Error(e)))
+    promise.then(handler, (e) -> handler(new Error(e)))?.done?()
     -> promise.abort?() if abort
   , ((value) -> [value, end()]))
 


### PR DESCRIPTION
Some major promise packages, such as https://github.com/kriskowal/q
will silently eat exceptions happening in promise handlers unless the
promise chain is ended with .done(). This patch ensures
Bacon.fromPromise ends such promise chains.

See https://github.com/kriskowal/q/wiki/Coming-from-jQuery#exception-handling

Fixes #501