### PR TITLE
Fix README typo

### DIFF
--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -304,7 +304,7 @@ If none of the factory methods above apply, you may of course roll your own Even
 """
 
 doc.fn "Bacon.fromBinder(subscribe)", """
-The parameter `subscribe` is a function that accepts a `sink` which is a function that your `subscribe` funtion can "push" events to.
+The parameter `subscribe` is a function that accepts a `sink` which is a function that your `subscribe` function can "push" events to.
 
 For example:
 


### PR DESCRIPTION
funtion -> function
