### PR TITLE
Raise error on Observable.[filter takeWhile skipWhile](EventStream)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,10 @@
+## NEXT
+
+- Throw an exception with a helpful error message if the user calls `filter(EventStream)`,
+  `takeWhile(EventStream)` or `skipWhile(EventStream)`
+
+  This is a potentially **backward incompatible change**.
+
 ## 0.7.52
 
 - Fix #560: unscheduling fail in case subscriber throws error

--- a/spec/specs/filter.coffee
+++ b/spec/specs/filter.coffee
@@ -37,3 +37,9 @@ describe "Property.filter", ->
         ok = series(2, [false, true, true, false]).toProperty()
         src.filter(ok)
       [2, 3])
+
+describe "Observable.filter(EventStream)", ->
+  it "should throw an error", ->
+    expect(
+      -> once(true).filter(once(true))
+    ).to.throw(Error, "Observable is not a Property : Bacon.once(true)")

--- a/spec/specs/skipwhile.coffee
+++ b/spec/specs/skipwhile.coffee
@@ -26,4 +26,8 @@ describe "EventStream.skipWhile", ->
   it "toString", ->
     expect(Bacon.never().skipWhile(1).toString()).to.equal("Bacon.never().skipWhile(function)")
 
-
+describe "Observable.skipWhile(EventStream)", ->
+  it "should throw an error", ->
+    expect(
+      -> once(true).skipWhile(once(true))
+    ).to.throw(Error, "Observable is not a Property : Bacon.once(true)")

--- a/spec/specs/takewhile.coffee
+++ b/spec/specs/takewhile.coffee
@@ -52,3 +52,8 @@ describe "Property.takeWhile", ->
           .toProperty().takeWhile(lessThan(3))
       [1, error("wat"), 2])
 
+describe "Observable.takeWhile(EventStream)", ->
+  it "should throw an error", ->
+    expect(
+      -> once(true).takeWhile(once(true))
+    ).to.throw(Error, "Observable is not a Property : Bacon.once(true)")

--- a/src/filter.coffee
+++ b/src/filter.coffee
@@ -1,7 +1,8 @@
-# build-dependencies: observable, property, eventstream
+# build-dependencies: observable, property, eventstream, helpers
 # build-dependencies: functionconstruction
 
 Bacon.Observable :: filter = (f, args...) ->
+  assertObservableIsProperty(f)
   convertArgsToFunction this, f, args, (f) ->
     withDescription(this, "filter", f, @withHandler (event) ->
       if event.filter(f)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -3,6 +3,8 @@ latter = (_, x) -> x
 former = (x, _) -> x
 cloneArray = (xs) -> xs.slice(0)
 assert = (message, condition) -> throw new Exception(message) unless condition
+assertObservableIsProperty = (x) ->
+  throw new Exception("Observable is not a Property : " + x ) if x instanceof Observable and !(x instanceof Property)
 assertEventStream = (event) -> throw new Exception("not an EventStream : " + event) unless event instanceof EventStream
 assertObservable = (event) -> throw new Exception("not an Observable : " + event) unless event instanceof Observable
 assertFunction = (f) -> assert "not a function : " + f, _.isFunction(f)

--- a/src/skipwhile.coffee
+++ b/src/skipwhile.coffee
@@ -1,6 +1,7 @@
-# build-dependencies: eventstream
+# build-dependencies: eventstream, helpers
 
 Bacon.EventStream :: skipWhile = (f, args...) ->
+  assertObservableIsProperty(f)
   ok = false
   convertArgsToFunction this, f, args, (f) ->
     withDescription(this, "skipWhile", f, @withHandler (event) ->

--- a/src/takewhile.coffee
+++ b/src/takewhile.coffee
@@ -1,6 +1,7 @@
-# build-dependencies: observable, filter
+# build-dependencies: observable, filter, helpers
 
 Bacon.Observable :: takeWhile = (f, args...) ->
+  assertObservableIsProperty(f)
   convertArgsToFunction this, f, args, (f) ->
     withDescription(this, "takeWhile", f, @withHandler (event) ->
       if event.filter(f)


### PR DESCRIPTION
At the moment Bacon silently accepts `EventStream` arguments to the combinators `filter`, `takeWhile` and `skipWhile`.

Passing an `EventStream` to these combinators is equal to passing them the value `true`. This can result in the programmer wondering why his combinators do not work as expected.

This pull request modifies  `filter`, `takeWhile` and `skipWhile` such that they will **throw an exception** if they receive an `EventStream` as the first argument.