### PR TITLE
Ignore unnecessary files in Bower configuration

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,8 @@
 
   This is a potentially **backward incompatible change**.
 
+- Ignore unnecessary files from Bower component
+
 ## 0.7.52
 
 - Fix #560: unscheduling fail in case subscriber throws error

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,33 @@
 {
   "name": "bacon",
   "version": "0.7.53",
-  "main": "dist/Bacon.js"
+  "main": "dist/Bacon.js",
+  "ignore": [
+    ".*",
+    "*.md",
+    "*.coffee",
+    "*.png",
+    "browsertest/",
+    "examples/",
+    "lib/",
+    "nuspec/",
+    "performance/",
+    "readme/",
+    "spec/",
+    "src/",
+    "build",
+    "coffeelint.json",
+    "component.json",
+    "package.json",
+    "grunt",
+    "release",
+    "test",
+    "runtests",
+    "testem.json",
+    "update-cdnjs",
+    "version",
+    "assemble*.js",
+    "build-deps.js",
+    "test-individually.js"
+  ]
 }


### PR DESCRIPTION
Cleanup the Bacon Bower component by ignoring unnecessary test, build, and source files in the Bower configuration. 
Resulting Bower package contents:
```
 bacon/
 +-dist/
 | +-Bacon.js
 | +-Bacon.min.js
 | +-Bacon.noAssert.js
 +-LICENSE
 +-bower.json
```