### PR TITLE
Fix the description for 'observable.map(f)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Use shim if you need to support legacy browsers or platforms.
 
 <a name="observable-map"></a>
 [`observable.map(f)`](#observable-map "observable.map(@ : Observable[A], f : A -> B) : Observable[B]") maps values using given function, returning a new
-EventStream. Instead of a function, you can also provide a constant
+stream/property. Instead of a function, you can also provide a constant
 value. Further, you can use a property extractor string like
 ".keyCode". So, if f is a string starting with a
 dot, the elements will be mapped to the corresponding field/function in the event

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -435,7 +435,7 @@ Use shim if you need to support legacy browsers or platforms.
 
 doc.fn "observable.map(@ : Observable[A], f : A -> B) : Observable[B]", """
 maps values using given function, returning a new
-EventStream. Instead of a function, you can also provide a constant
+stream/property. Instead of a function, you can also provide a constant
 value. Further, you can use a property extractor string like
 ".keyCode". So, if f is a string starting with a
 dot, the elements will be mapped to the corresponding field/function in the event


### PR DESCRIPTION
The current documentation for `observable.map` states that this function returns a new EventStream, which is not accurate. That lead me to believe that if used in a property the result would be an 'EventStream' rather than a property, which I thought was odd. However, after I tested it I realized that it returns a property when it's used with a property and  stream when it's used with  stream, which is what I would expect.