### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
       "url": "https://twitter.com/xflowwolf"
     }
   ],
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "babel": "^4.5.5",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/