### PR TITLE
Add Observable.doLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,10 @@ or just
 myStream.log()
 ```
 
+<a name="observable-dolog"></a>
+[`observable.doLog()`](#observable-dolog "observable.doLog()") Behaves like [`observable.log`](#observable-log) but does not subscribe to the event stream. You
+can think of [`doLog`](#observable-dolog) as a variant of [`doAction`](#observable-doaction).
+
 <a name="observable-combine"></a>
 [`observable.combine(property2, f)`](#observable-combine "observable.combine(property2, f)") combines the latest values of the two
 streams or properties using a two-arg function. Similarly to [`scan`](#observable-scan), you can use a

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -805,6 +805,11 @@ myStream.log()
 ```
 """
 
+doc.fn "observable.doLog()", """
+Behaves like `log` but does not subscribe to the event stream. You
+can think of `doLog` as a variant of `doAction`.
+"""
+
 doc.fn "observable.combine(property2, f)", """
 combines the latest values of the two
 streams or properties using a two-arg function. Similarly to `scan`, you can use a

--- a/spec/specs/dolog.coffee
+++ b/spec/specs/dolog.coffee
@@ -29,18 +29,18 @@ describe "Observable.doLog", ->
       console.log = (args...) -> loggedValues = args
       Bacon.constant(1).doLog(true).onValue(->)
     expect(loggedValues[0]).to.equal(true)
-  it "logs Error events as strings", (done) ->
+  it "logs Error events as strings", ->
     loggedValues = undefined
     preservingLog ->
       console.log = (args...) -> loggedValues = args
-      new Bacon.Error('err').doLog(true).onValue(->)
-    expect(loggedValues).to.equal(true)
-  it "logs End events as strings", (done) ->
+      once(Bacon.Error('err')).doLog(true).onValue(->)
+    expect(loggedValues).to.deep.equal [true, '<end>']
+  it "logs End events as strings", ->
     loggedValues = undefined
     preservingLog ->
       console.log = (args...) -> loggedValues = args
-      new Bacon.End().doLog(true).onValue(->)
-    expect(loggedValues).to.equal(true)
+      once(new Bacon.End()).doLog(true).onValue(->)
+    expect(loggedValues).to.deep.equal [true, '<end>']
   it "toString", ->
     expect(Bacon.never().doLog().toString()).to.equal("Bacon.never().doLog()")
 

--- a/spec/specs/dolog.coffee
+++ b/spec/specs/dolog.coffee
@@ -1,0 +1,47 @@
+# build-dependencies: factories
+
+describe "Observable.doLog", ->
+  preservingLog = (f) ->
+    originalConsole = console
+    originalLog = console.log
+    try
+      f()
+    finally
+      global.console = originalConsole
+      console.log = originalLog
+
+  it "does not consume the event", (done) ->
+    streamWithOneEvent = once({}).doLog('hello bacon')
+    streamWithOneEvent.onValue(->
+      done()
+    )
+  it "does not crash", ->
+    preservingLog ->
+      console.log = ->
+      Bacon.constant(1).doLog().onValue()
+  it "does not crash in case console.log is not defined", ->
+    preservingLog ->
+      console.log = undefined
+      Bacon.constant(1).doLog().onValue()
+  it "logs event values as themselves (doesn't stringify)", ->
+    loggedValues = undefined
+    preservingLog ->
+      console.log = (args...) -> loggedValues = args
+      Bacon.constant(1).doLog(true).onValue(->)
+    expect(loggedValues[0]).to.equal(true)
+  it "logs Error events as strings", (done) ->
+    loggedValues = undefined
+    preservingLog ->
+      console.log = (args...) -> loggedValues = args
+      new Bacon.Error('err').doLog(true).onValue(->)
+    expect(loggedValues).to.equal(true)
+  it "logs End events as strings", (done) ->
+    loggedValues = undefined
+    preservingLog ->
+      console.log = (args...) -> loggedValues = args
+      new Bacon.End().doLog(true).onValue(->)
+    expect(loggedValues).to.equal(true)
+  it "toString", ->
+    expect(Bacon.never().doLog().toString()).to.equal("Bacon.never().doLog()")
+
+

--- a/src/dolog.coffee
+++ b/src/dolog.coffee
@@ -1,0 +1,7 @@
+# build-dependencies: observable
+
+Bacon.Observable :: doLog = (args...) ->
+  withDesc(new Bacon.Desc(this, "doLog", args), @withHandler (event) ->
+    console?.log?(args..., event.log())
+    @push event
+  )

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@
 // build-dependencies: diff
 // build-dependencies: doaction
 // build-dependencies: doerror
+// build-dependencies: dolog
 // build-dependencies: endonerror
 // build-dependencies: errors
 // build-dependencies: factories


### PR DESCRIPTION
The function `Observable.log` is problematic, because it consumes events from `EventStream`.

Consider the following example:

```javascript
var o = Bacon.once({}).log('hello')
o.onValue(doStuff)
```

Above, Bacon will never call the `doStuff` function that we pass to `o.onValue`.

Bacon [documentation on log](https://github.com/baconjs/bacon.js/#observable-log) does say that `log` should be used for testing and debugging purposes. This pull request attempts to improve the logging facilities of Bacon by adding a logger function that developers can safely use in production.