### PR TITLE
Clarify documentation of doLog()

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,8 +789,11 @@ myStream.log()
 ```
 
 <a name="observable-dolog"></a>
-[`observable.doLog()`](#observable-dolog "observable.doLog()") Behaves like [`observable.log`](#observable-log) but does not subscribe to the event stream. You
-can think of [`doLog`](#observable-dolog) as a variant of [`doAction`](#observable-doaction).
+[`observable.doLog()`](#observable-dolog "observable.doLog()") logs each value of the Observable to the console. doLog() behaves like [`log`](#observable-log)
+but does not subscribe to the event stream. You can think of doLog() as a
+logger function that – unlike log() – is safe to use in production. doLog() is
+safe, because it does not cause the same surprising side-effects as log()
+does.
 
 <a name="observable-combine"></a>
 [`observable.combine(property2, f)`](#observable-combine "observable.combine(property2, f)") combines the latest values of the two

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -806,8 +806,11 @@ myStream.log()
 """
 
 doc.fn "observable.doLog()", """
-Behaves like `log` but does not subscribe to the event stream. You
-can think of `doLog` as a variant of `doAction`.
+logs each value of the Observable to the console. doLog() behaves like `log`
+but does not subscribe to the event stream. You can think of doLog() as a
+logger function that – unlike log() – is safe to use in production. doLog() is
+safe, because it does not cause the same surprising side-effects as log()
+does.
 """
 
 doc.fn "observable.combine(property2, f)", """


### PR DESCRIPTION
The current documentation on `doLog` is inadequate, because it does not mention that `doLog` is also a variant of `doError`. `doLog` is a variant of `doError`, since it also logs error events.

This pull request removes the reference to `doAction` and replaces it with a statement about production-readiness of `doLog`.