### PR TITLE
Add Bacon.try

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ $("#my-div").asEventStream("click", function(event, args) { return args[0] })
 
 <a name="bacon-frompromise"></a>
 [`Bacon.fromPromise(promise [, abort] [, eventTransformer])`](#bacon-frompromise "Bacon.fromPromise(promise : Promise[A] [, abort : boolean][, eventTransformer]) : EventStream[A]") creates an EventStream from a Promise object such as JQuery Ajax.
-This stream will contain a single value or an error, followed immediately by stream end.  
+This stream will contain a single value or an error, followed immediately by stream end.
 You can use the optional abort flag (i.e. ´fromPromise(p, true)´ to have the `abort` method of the given promise be called when all subscribers have been removed from the created stream.
 You can also pass an optional function that transforms the promise value into Events. The default is to transform the value into `[new Bacon.Next(value), new Bacon.End()]`.
 Check out this [example](https://github.com/raimohanska/baconjs-examples/blob/master/resources/public/index.html).
@@ -436,7 +436,7 @@ Common methods are listed below.
 <a name="observable-subscribe"></a>
 [`observable.subscribe(f)`](#observable-subscribe "observable.subscribe(f)") subscribes given handler function to event stream. Function will receive Event objects (see below).
 The subscribe() call returns a `unsubscribe` function that you can call to unsubscribe.
-You can also unsubscribe by returning [`Bacon.noMore`](#bacon-nomore) from the handler function as a reply 
+You can also unsubscribe by returning [`Bacon.noMore`](#bacon-nomore) from the handler function as a reply
 to an Event.
 `stream.subscribe` and `property.subscribe` behave similarly, except that the latter also
 pushes the initial value of the property, in case there is one.
@@ -1538,7 +1538,7 @@ Bacon.when([a,b,c], combine)
 Note that [`Bacon.when`](#bacon-when) does not trigger updates for events from Properties though;
 if you use a Property in your pattern, its value will be just sampled when all the
 other sources (EventStreams) have a value. This is useful when you need a value of a Property
-in your calculations. If you want your pattern to fire for a Property too, you can 
+in your calculations. If you want your pattern to fire for a Property too, you can
 convert it into an EventStream using [`property.changes()`](#property-changes) or [`property.toEventStream()`](#property-toeventstream)
 
 <a name="bacon-update"></a>

--- a/README.md
+++ b/README.md
@@ -1460,12 +1460,18 @@ Especially [`map`](#observable-map) doesn't do so. If you want to map things
 and wrap caught errors into Error events, you can do the following:
 
 ```js
-var source, dangerousFunction // <- your stuff
-wrapped = source.flatMap(function(x) {
-  try
-    return dangerousFunction(x)
-  catch (e)
-    return new Bacon.Error(e)
+wrapped = source.flatMap(Bacon.try(dangerousOperation))
+```
+
+For example, you can use `Bacon.try` to handle JSON parse errors:
+
+```js
+var jsonStream = Bacon
+  .once('{"this is invalid json"')
+  .flatMap(Bacon.try(JSON.parse))
+
+jsonStream.onError(function(err) {
+  console.error("Failed to parse JSON", err)
 })
 ```
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- Add `Bacon.try`
+
 ## 0.7.72
 
 - fix #621: loading fails with webpack in some configurations

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1532,12 +1532,18 @@ Especially [`map`](#observable-map) doesn't do so. If you want to map things
 and wrap caught errors into Error events, you can do the following:
 
 ```js
-var source, dangerousFunction // <- your stuff
-wrapped = source.flatMap(function(x) {
-  try
-    return dangerousFunction(x)
-  catch (e)
-    return new Bacon.Error(e)
+wrapped = source.flatMap(Bacon.try(dangerousOperation))
+```
+
+For example, you can use `Bacon.try` to handle JSON parse errors:
+
+```js
+var jsonStream = Bacon
+  .once('{"this is invalid json"')
+  .flatMap(Bacon.try(JSON.parse))
+
+jsonStream.onError(function(err) {
+  console.error("Failed to parse JSON", err)
 })
 ```
 

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -169,7 +169,7 @@ $("#my-div").asEventStream("click", function(event, args) { return args[0] })
 
 doc.fn "Bacon.fromPromise(promise : Promise[A] [, abort : boolean][, eventTransformer]) : EventStream[A]", """
 creates an EventStream from a Promise object such as JQuery Ajax.
-This stream will contain a single value or an error, followed immediately by stream end.  
+This stream will contain a single value or an error, followed immediately by stream end.
 You can use the optional abort flag (i.e. ´fromPromise(p, true)´ to have the `abort` method of the given promise be called when all subscribers have been removed from the created stream.
 You can also pass an optional function that transforms the promise value into Events. The default is to transform the value into `[new Bacon.Next(value), new Bacon.End()]`.
 Check out this [example](https://github.com/raimohanska/baconjs-examples/blob/master/resources/public/index.html).
@@ -413,7 +413,7 @@ Common methods are listed below.
 doc.fn "observable.subscribe(f)", """
 subscribes given handler function to event stream. Function will receive Event objects (see below).
 The subscribe() call returns a `unsubscribe` function that you can call to unsubscribe.
-You can also unsubscribe by returning `Bacon.noMore` from the handler function as a reply 
+You can also unsubscribe by returning `Bacon.noMore` from the handler function as a reply
 to an Event.
 `stream.subscribe` and `property.subscribe` behave similarly, except that the latter also
 pushes the initial value of the property, in case there is one.
@@ -1612,7 +1612,7 @@ Bacon.when([a,b,c], combine)
 Note that `Bacon.when` does not trigger updates for events from Properties though;
 if you use a Property in your pattern, its value will be just sampled when all the
 other sources (EventStreams) have a value. This is useful when you need a value of a Property
-in your calculations. If you want your pattern to fire for a Property too, you can 
+in your calculations. If you want your pattern to fire for a Property too, you can
 convert it into an EventStream using `property.changes()` or `property.toEventStream()`
 """
 

--- a/spec/specs/try.coffee
+++ b/spec/specs/try.coffee
@@ -1,0 +1,20 @@
+# build-dependencies: flatmap, doerror, doaction
+describe "Bacon.try", ->
+  it "maps the value over the function", ->
+    Bacon
+      .once('{"valid json": true}')
+      .flatMap(Bacon.try(JSON.parse))
+      .doError(() -> throw "Bacon.try test failed")
+      .onValue(() -> "all ok")
+
+  it "returns a Bacon.Error if the mapper function throws an exception", ->
+    Bacon
+      .once('{"invalid json: true}')
+      .flatMap(Bacon.try(JSON.parse))
+      .doAction(() -> throw "Bacon.try test failed")
+      .onError((err) ->
+        if err instanceof SyntaxError
+          "all ok"
+        else
+          throw "Bacon.try did not emit an expected error event"
+      )

--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,7 @@
 // build-dependencies: take
 // build-dependencies: takewhile
 // build-dependencies: takeuntil
+// build-dependencies: try
 // build-dependencies: update
 // build-dependencies: when
 // build-dependencies: zip

--- a/src/try.coffee
+++ b/src/try.coffee
@@ -1,0 +1,7 @@
+# build-dependencies: core, once
+Bacon.try = (f) ->
+  (value) ->
+    try
+      Bacon.once(f(value))
+    catch e
+      new Bacon.Error(e)


### PR DESCRIPTION
`Bacon.try` is a shorthand for

```javascript
o.flatMap(v => { 
  try {
    return f(v)
  } catch (e) {
    return new Bacon.Error(e)
  }
})
```

The README contains an example of how to use `Bacon.try`.

Edit: renamed `try` to `tryMap`.
Edit2: renamed `Observable#tryMap` to `Bacon.try`