### PR TITLE
Feature/group by

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,10 @@ For example:
     console.log(obs.toString())
     --> Bacon.once(1).times(-1)
 
+<a name="observable-groupby"></a>
+[`observable.groupBy(keyF [, limitF])`](#observable-groupby "observable.groupBy(@ : Observable[A], keyF[, limitF]) : Observable[Observable[A]]") Groups stream events to new streams by `keyF`. Optional `limitF` can be provided to limit grouped
+stream life.
+
 EventStream
 -----------
 

--- a/README.md
+++ b/README.md
@@ -903,7 +903,42 @@ For example:
 
 <a name="observable-groupby"></a>
 [`observable.groupBy(keyF [, limitF])`](#observable-groupby "observable.groupBy(@ : Observable[A], keyF[, limitF]) : Observable[Observable[A]]") Groups stream events to new streams by `keyF`. Optional `limitF` can be provided to limit grouped
-stream life.
+stream life. Stream transformed by `limitF` is passed on if provided. `limitF` gets grouped stream
+and the original event causing the stream to start as parameters.
+
+Calculator for grouped consecutive values until group is cancelled:
+
+    var events = [
+      {id: 1, type: "add", val: 3 },
+      {id: 2, type: "add", val: -1 },
+      {id: 1, type: "add", val: 2 },
+      {id: 2, type: "cancel"},
+      {id: 3, type: "add", val: 2 },
+      {id: 3, type: "cancel"},
+      {id: 1, type: "add", val: 1 },
+      {id: 1, type: "add", val: 2 },
+      {id: 1, type: "cancel"}
+    ]
+
+    function keyF(event) {
+      return event.id
+    }
+
+    function limitF(groupedStream, groupStartingEvent) {
+      var cancel = groupedStream.filter(function(x) { return x.type === "cancel"}).take(1)
+      var adds = groupedStream.filter(function(x) { return x.type === "add" })
+      adds.takeUntil(cancel).map(".val")
+    }
+
+    Bacon.sequentially(2, events)
+      .groupBy(keyF, limitF)
+      .flatMap(function(groupedStream) {
+        return groupedStream.fold(0, function(acc, x) { return acc + x })
+      })
+      .onValue(function(sum) {
+        console.log(sum)
+        // returns [-1, 2, 8] in an order
+      })
 
 EventStream
 -----------

--- a/performance/MemoryTest.coffee
+++ b/performance/MemoryTest.coffee
@@ -60,6 +60,10 @@ title "EventStream::mergeAll(stream1, stream2, stream3, stream4)"
 createNObservable 500, ->
   Bacon.mergeAll(eventStream(), eventStream(), eventStream(), eventStream())
 
+title "EventStream::groupBy(keyF, limitF)"
+createNObservable 500, ->
+  Bacon.sequentially(0, [1,2,3,4]).groupBy((x) -> x)
+
 diamond = (src, width, depth) ->
   if depth == 0
     src

--- a/spec/specs/groupby.coffee
+++ b/spec/specs/groupby.coffee
@@ -1,0 +1,82 @@
+# build-dependencies: flatMap, fold, concat, take, takeWhile, takeUntil, map
+
+describe "EventStream.groupBy", ->
+  flattenAndConcat = (obs) ->
+    obs.flatMap((obs) ->
+      obs.fold([], (xs,x) ->
+        xs.concat(x)))
+
+  flattenAndMerge = (obs) ->
+    obs.flatMap(Bacon._.id)
+
+  takeWhileInclusive = (obs, f) ->
+    obs.withHandler (event) ->
+      if event.filter(f)
+        @push event
+      else
+        @push event
+        @push new Bacon.End()
+        Bacon.noMore
+
+  describe "without limiting function", ->
+    expectStreamEvents(
+      ->
+        flattenAndConcat series(2, [1,2,2,3,1,2,2,3]).groupBy(Bacon._.id)
+      [[1,1],[2,2,2,2],[3,3]], unstable)
+    expectStreamEvents(
+      ->
+        flattenAndMerge series(2, [1,2,2,3,1,2,2,3]).groupBy(Bacon._.id)
+      [1,2,2,3,1,2,2,3])
+  describe "with limiting function", ->
+    expectStreamEvents(
+      ->
+        flattenAndConcat series(2, [1,2,2,3,1,2,2,3]).groupBy(Bacon._.id, (x) -> x.take(2))
+      [[2,2],[1,1],[2,2],[3,3]])
+    expectStreamEvents(
+      ->
+        flattenAndMerge series(2, [1,2,2,3,1,2,2,3]).groupBy(Bacon._.id, (x) -> x.take(2))
+      [1,2,2,3,1,2,2,3])
+  describe "when mapping all values to same key", ->
+    expectStreamEvents(
+      ->
+        flattenAndConcat series(2, [1,2,2,3,1,2,2,3]).groupBy((x) -> "")
+      [[1,2,2,3,1,2,2,3]])
+  describe "when using accumulator function", ->
+    expectStreamEvents(
+      ->
+        flattenAndConcat series(2, [1,2,2,3,1,2,2,3]).groupBy(Bacon._.id, (x) -> x.fold(0, (x,y) -> x+y))
+      [[2], [8], [6]], unstable)
+    expectStreamEvents(
+      ->
+        flattenAndMerge series(2, [1,2,2,3,1,2,2,3]).groupBy(Bacon._.id, (x) -> x.fold(0, (x,y) -> x+y))
+      [2, 8, 6], unstable)
+  describe "scenario #402", ->
+    expectStreamEvents(
+      ->
+        flattenAndConcat (series(2, [{k:1, t:"start"}, {k:2, t:"start"}, {k: 1, t:"data"}, {k: 1, t: "end"}, {k: 1, t: "start"}])
+          .groupBy(((x) -> x.k), (x) -> takeWhileInclusive x, (x) -> x.t != "end"))
+      [[{k:1, t:"start"}, {k: 1, t:"data"}, {k: 1, t:"end"}], [{k:2, t:"start"}], [{k:1, t:"start"}]], unstable)
+  describe "scenario calculating sums by continuous groups", ->
+    events = [
+      {id: 1, val: 3, type: "add"},
+      {id: 2, val: -1, type: "add"},
+      {id: 1, val: 2, type: "add"},
+      {id: 2, type: "cancel"},
+      {id: 3, val: 2, type: "add"},
+      {id: 3, type: "cancel"},
+      {id: 1, val: 1, type: "add"},
+      {id: 1, val: 2, type: "add"},
+      {id: 1, type: "cancel"}
+    ]
+    expectStreamEvents(
+      ->
+        keyF = (x) -> x.id
+        limitF = (stream, origX) ->
+          cancel = stream.filter((x) -> x.type == "cancel").take(1)
+          adds = stream.filter((x) -> x.type == "add")
+          adds.takeUntil(cancel).map(".val")
+
+        series(2, events)
+          .groupBy(keyF, limitF)
+          .flatMap((groupStream) -> groupStream.fold(0, (acc, x) -> acc + x))
+      [-1, 2, 8])

--- a/src/groupby.coffee
+++ b/src/groupby.coffee
@@ -1,0 +1,16 @@
+# build-dependencies: filter, map, once, concat, observable
+
+Bacon.Observable :: groupBy = (keyF, limitF = Bacon._.id) ->
+  streams = {}
+  src = this
+  src.filter((x) -> !streams[keyF(x)])
+  .map (x) ->
+    key = keyF(x)
+    similar = src.filter((x) -> keyF(x) == key)
+    data = Bacon.once(x).concat(similar)
+    limited = limitF(data, x).withHandler((event) ->
+      @push(event)
+      if event.isEnd()
+        delete streams[key]
+    )
+    streams[key] = limited

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@
 // build-dependencies: flatmapwithconcurrencylimit
 // build-dependencies: fold
 // build-dependencies: frompoll
+// build-dependencies: groupby
 // build-dependencies: holdwhen
 // build-dependencies: interval
 // build-dependencies: jquery


### PR DESCRIPTION
`observable.groupBy(keyF [, limitF])` Groups stream events to new streams by keyF. Optional limitF can be provided to limit grouped stream life. Stream transformed by limitF is passed on if provided. limitF gets grouped stream and the original event causing the stream to start as parameters.

Calculator for grouped consecutive values until group is cancelled:

```
var events = [
  {id: 1, type: "add", val: 3 },
  {id: 2, type: "add", val: -1 },
  {id: 1, type: "add", val: 2 },
  {id: 2, type: "cancel"},
  {id: 3, type: "add", val: 2 },
  {id: 3, type: "cancel"},
  {id: 1, type: "add", val: 1 },
  {id: 1, type: "add", val: 2 },
  {id: 1, type: "cancel"}
]

function keyF(event) {
  return event.id
}

function limitF(groupedStream, groupStartingEvent) {
  var cancel = groupedStream.filter(function(x) { return x.type === "cancel"}).take(1)
  var adds = groupedStream.filter(function(x) { return x.type === "add" })
  adds.takeUntil(cancel).map(".val")
}

Bacon.sequentially(2, events)
  .groupBy(keyF, limitF)
  .flatMap(function(groupedStream) {
    return groupedStream.fold(0, function(acc, x) { return acc + x })
  })
  .onValue(function(sum) {
    console.log(sum)
    // returns [-1, 2, 8] in an order
  })
```