### PR TITLE
Allow `combineWith` to take streams argument as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,15 @@ function sum3(x,y,z) { return x + y + z }
 Bacon.combineWith(sum3, p1, p2, p3)
 ```
 
+<a name="bacon-combinewith-streams-array"></a>
+[`Bacon.combineWith(f, streams)`](#bacon-combinewith-streams-array "Bacon.combineWith(f, streams)") like above, but with streams provided as a single array as opposed to a list
+of arguments.
+
+```js
+streams = [Bacon.constant(1), Bacon.constant(2)]
+Bacon.combineWith(Math.max, streams)
+```
+
 <a name="bacon-combinetemplate"></a>
 [`Bacon.combineTemplate(template)`](#bacon-combinetemplate "Bacon.combineTemplate(template)") combines Properties, EventStreams and
 constant values using a template

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1208,6 +1208,16 @@ Bacon.combineWith(sum3, p1, p2, p3)
 ```
 """
 
+doc.fnOverload "Bacon.combineWith(f, streams)", "streams-array", """
+like above, but with streams provided as a single array as opposed to a list
+of arguments.
+
+```js
+streams = [Bacon.constant(1), Bacon.constant(2)]
+Bacon.combineWith(Math.max, streams)
+```
+"""
+
 doc.fn "Bacon.combineTemplate(template)", """
 combines Properties, EventStreams and
 constant values using a template

--- a/spec/specs/combine.coffee
+++ b/spec/specs/combine.coffee
@@ -155,6 +155,13 @@ describe "Bacon.combineWith", ->
       ->
         Bacon.combineWith(-> 1)
       [1])
+  describe "works with streams provided as an array", ->
+    expectPropertyEvents(
+      ->
+        f = Math.max
+        Bacon.combineWith(f, [Bacon.constant(0), Bacon.constant(1)])
+      [1]
+    )
   it "toString", ->
     expect(Bacon.combineWith((->), Bacon.never()).toString()).to.equal("Bacon.combineWith(function,Bacon.never())")
 

--- a/src/combine.coffee
+++ b/src/combine.coffee
@@ -17,6 +17,8 @@ Bacon.combineAsArray = (streams...) ->
 Bacon.onValues = (streams..., f) -> Bacon.combineAsArray(streams).onValues(f)
 
 Bacon.combineWith = (f, streams...) ->
+  if (streams.length == 1 and isArray(streams[0]))
+    streams = streams[0]
   withDesc(new Bacon.Desc(Bacon, "combineWith", [f, streams...]), Bacon.combineAsArray(streams).map (values) -> f(values...))
 
 Bacon.Observable :: combine = (other, f) ->


### PR DESCRIPTION
I ran into this while trying to combine an array of existing streams with `Math.max`, which is reflected in the test.

(Also: both `grunt assemble` and `./assemble.js` failed for me.)