### PR TITLE
Remove unnecessary new-less constructor for Bacon.Event

### DIFF
--- a/spec/specs/event.coffee
+++ b/spec/specs/event.coffee
@@ -1,6 +1,5 @@
 describe "Bacon.Event", ->
   it "can be instatiated without new", ->
-    expect(Bacon.Event()).to.be.an.instanceof(Bacon.Event)
     expect(Bacon.Initial()).to.be.an.instanceof(Bacon.Initial)
     expect(Bacon.Next()).to.be.an.instanceof(Bacon.Next)
     expect(Bacon.End()).to.be.an.instanceof(Bacon.End)

--- a/src/event.coffee
+++ b/src/event.coffee
@@ -4,8 +4,6 @@ eventIdCounter = 0
 
 class Event
   constructor: ->
-    if this not instanceof Event
-      return new Event
     @id = (++eventIdCounter)
   isEvent: -> true
   isEnd: -> false


### PR DESCRIPTION
As suggested by @raimohanska on #628.