### PR TITLE
Resolve linter errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
     "Exception": true,
     "nextEvent": true,
     "endEvent": true,
-    "withDescription": true
+    "withDescription": true,
+    "withDesc": true
   },
   "rules": {
     "strict": 0

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -26,7 +26,7 @@
     },
     "newlines_after_classes": {
         "value": 3,
-        "level": "error"
+        "level": "ignore"
     },
     "no_empty_param_list": {
         "level": "error"
@@ -49,4 +49,3 @@
         "level": "error"
     }
 }
-

--- a/src/argumentstoobservables.coffee
+++ b/src/argumentstoobservables.coffee
@@ -10,4 +10,4 @@ argumentsToObservablesAndFunction = (args) ->
   if _.isFunction args[0]
     [argumentsToObservables(Array::slice.call(args, 1)), args[0]]
   else
-    [argumentsToObservables(Array::slice.call(args, 0, args.length-1)), _.last(args) ]
+    [argumentsToObservables(Array::slice.call(args, 0, args.length - 1)), _.last(args) ]

--- a/src/event.coffee
+++ b/src/event.coffee
@@ -61,7 +61,7 @@ class Initial extends Next
 class End extends Event
   constructor: ->
     if this not instanceof End
-      return new End
+      return new End()
   isEnd: -> true
   fmap: -> this
   apply: -> this

--- a/src/retry.coffee
+++ b/src/retry.coffee
@@ -17,9 +17,7 @@ Bacon.retry = (options) ->
       valueStream = -> source().endOnError().withHandler (event) ->
         if event.isError()
           error = event
-          if isRetryable(error.error) and retries > 0
-            # will retry
-          else
+          unless isRetryable(error.error) and retries > 0
             finished = true # no more retries
             @push event # push final error to subscriber
         else


### PR DESCRIPTION
The default grunt task passes again. This is done by both minor configuration changes and fixing minor inconsistencies in source files.