### PR TITLE
Make fromEvent work for sources with missing removeListener

### DIFF
--- a/spec/specs/fromevent.coffee
+++ b/spec/specs/fromevent.coffee
@@ -67,6 +67,15 @@ describe "Bacon.fromEvent", ->
     expect(values).to.deep.equal ["test"]
     expect(src.cleaned).to.equal(true)
   
+  it "should create EventStream even if removeListener method missing", ->
+    values = []
+    src = {
+      addListener: (type, callback) -> callback(type)
+    }
+    take(1, Bacon.fromEvent(src, "test")).onValue (value) ->
+      values.push(value)
+    expect(values).to.deep.equal ["test"]
+  
   bindUnbindSource = -> {
     bind: (type, callback) -> callback(type)
     unbind: (callback) -> this.cleaned = true

--- a/src/fromevent.coffee
+++ b/src/fromevent.coffee
@@ -27,6 +27,9 @@ findHandlerMethods = (target) ->
   for pair in eventMethods
     methodPair = [target[pair[0]], target[pair[1]]]
     return methodPair if methodPair[0] and methodPair[1]
+  for pair in eventMethods
+    addListener = target[pair[0]]
+    return [addListener, ->] if addListener
   throw new Error("No suitable event methods in " + target)
 
 Bacon.fromEventTarget = (target, eventName, eventTransformer) ->


### PR DESCRIPTION
Make fromEvent work for sources with missing removeListener/removeEventListener/unbind/off method

Motivation for this is that some sources only have an `on` / `addListener` /  `addEventListener` method without corresponding `off`/ `removeListener` / `removeEventListener` method.

After the change, the `fromEvent` method will still prefer a found method pair, but will settle for an `addListener` only if no pair is found. This means that it won't break existing applications using `fromEvent`, but will make the method useful for some new cases.

Waddyathink?