### PR TITLE
Remove instanceof checks for Bacon objects

### DIFF
--- a/src/_.coffee
+++ b/src/_.coffee
@@ -56,7 +56,7 @@ _ = {
   cached: (f) ->
     value = None
     ->
-      if value == None
+      if value?._isNone
         value = f()
         f = undefined
       value

--- a/src/describe.coffee
+++ b/src/describe.coffee
@@ -1,6 +1,8 @@
 # build-dependencies: _, source
 
 class Desc
+  _isDesc: true
+
   constructor: (@context, @method, @args) ->
   deps: ->
     @cached or= findDeps([@context].concat(@args))
@@ -8,7 +10,7 @@ class Desc
     _.toString(@context) + "." + _.toString(@method) + "(" + _.map(_.toString, @args) + ")"
 
 describe = (context, method, args...) ->
-  if (context or method) instanceof Desc
+  if (context or method)?._isDesc
     context or method
   else
     new Desc(context, method, args)
@@ -22,7 +24,7 @@ findDeps = (x) ->
     _.flatMap findDeps, x
   else if isObservable(x)
     [x]
-  else if x instanceof Source
+  else if x?._isSource
     [x.obs]
   else
     []

--- a/src/event.coffee
+++ b/src/event.coffee
@@ -3,6 +3,8 @@
 eventIdCounter = 0
 
 class Event
+  _isEvent: true
+
   constructor: ->
     @id = (++eventIdCounter)
   isEvent: -> true
@@ -16,11 +18,13 @@ class Event
   log: -> @toString()
 
 class Next extends Event
+  _isNext: true
+
   constructor: (valueF, eager) ->
     if this not instanceof Next
       return new Next(valueF, eager)
     super()
-    if !eager && _.isFunction(valueF) || valueF instanceof Next
+    if !eager && _.isFunction(valueF) || valueF?._isNext
       @valueF = valueF
       @valueInternal = undefined
     else
@@ -29,7 +33,7 @@ class Next extends Event
   isNext: -> true
   hasValue: -> true
   value: ->
-    if @valueF instanceof Next
+    if @valueF?._isNext
       @valueInternal = @valueF.value()
       @valueF = undefined
     else if @valueF
@@ -49,6 +53,8 @@ class Next extends Event
   log: -> @value()
 
 class Initial extends Next
+  _isInitial: true
+
   constructor: (valueF, eager) ->
     if this not instanceof Initial
       return new Initial(valueF, eager)
@@ -87,5 +93,4 @@ Bacon.Error = Error
 initialEvent = (value) -> new Initial(value, true)
 nextEvent = (value) -> new Next(value, true)
 endEvent = -> new End()
-# instanceof more performant than x.?isEvent?()
-toEvent = (x) -> if x instanceof Event then x else nextEvent x
+toEvent = (x) -> if x?._isEvent then x else nextEvent x

--- a/src/eventstream.coffee
+++ b/src/eventstream.coffee
@@ -6,6 +6,8 @@
 # build-dependencies: helpers
 
 class EventStream extends Observable
+  _isEventStream: true
+
   constructor: (desc, subscribe, handler) ->
     if this not instanceof EventStream
       return new EventStream(desc, subscribe, handler)

--- a/src/flatmap.coffee
+++ b/src/flatmap.coffee
@@ -24,7 +24,7 @@ flatMap_ = (root, f, firstOnly, limit) ->
           checkEnd(unsubMe)
           Bacon.noMore
         else
-          if event instanceof Initial
+          if event?._isInitial
             # To support Property as the spawned stream
             event = event.toNext()
           reply = sink event

--- a/src/frombinder.coffee
+++ b/src/frombinder.coffee
@@ -16,7 +16,7 @@ Bacon.fromBinder = (binder, eventTransformer = _.id) ->
           shouldUnbind = true
     unbinder = binder (args...) ->
       value = eventTransformer.apply(this, args)
-      unless isArray(value) and _.last(value) instanceof Event
+      unless isArray(value) and _.last(value)?._isEvent
         value = [value]
       reply = Bacon.more
       for event in value

--- a/src/functionconstruction.coffee
+++ b/src/functionconstruction.coffee
@@ -50,7 +50,7 @@ makeFunction = (f, args) ->
   makeFunction_(f, args...)
 
 convertArgsToFunction = (obs, f, args, method) ->
-  if f instanceof Property
+  if f?._isProperty
     sampled = f.sampledBy(obs, (p,s) -> [p,s])
     method.call(sampled, ([p, s]) -> p)
       .map(([p, s]) -> s)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -4,12 +4,12 @@ former = (x, _) -> x
 cloneArray = (xs) -> xs.slice(0)
 assert = (message, condition) -> throw new Exception(message) unless condition
 assertObservableIsProperty = (x) ->
-  throw new Exception("Observable is not a Property : " + x ) if x instanceof Observable and !(x instanceof Property)
-assertEventStream = (event) -> throw new Exception("not an EventStream : " + event) unless event instanceof EventStream
-assertObservable = (event) -> throw new Exception("not an Observable : " + event) unless event instanceof Observable
+  throw new Exception("Observable is not a Property : " + x ) if x?._isObservable and !(x?._isProperty)
+assertEventStream = (event) -> throw new Exception("not an EventStream : " + event) unless event?._isEventStream
+assertObservable = (event) -> throw new Exception("not an Observable : " + event) unless event?._isObservable
 assertFunction = (f) -> assert "not a function : " + f, _.isFunction(f)
 isArray = (xs) -> xs instanceof Array
-isObservable = (x) -> x instanceof Observable
+isObservable = (x) -> x?._isObservable
 assertArray = (xs) -> throw new Exception("not an array : " + xs) unless isArray(xs)
 assertNoArguments = (args) -> assert "no arguments supported", args.length == 0
 assertString = (x) -> throw new Exception("not a string : " + x) unless typeof x == "string"

--- a/src/observable.coffee
+++ b/src/observable.coffee
@@ -9,6 +9,8 @@ idCounter = 0
 registerObs = ->
 
 class Observable
+  _isObservable: true
+
   constructor: (@desc) ->
     @id = ++idCounter
     @initialDesc = @desc

--- a/src/optional.coffee
+++ b/src/optional.coffee
@@ -1,4 +1,6 @@
 class Some
+  _isSome: true
+
   constructor: (@value) ->
   getOrElse: -> @value
   get: -> @value
@@ -17,6 +19,7 @@ class Some
   toString: -> @inspect()
 
 None = {
+  _isNone: true
   getOrElse: (value) -> value
   filter: -> None
   map: -> None
@@ -28,7 +31,7 @@ None = {
 }
 
 toOption = (v) ->
-  if v instanceof Some or v == None
+  if v?._isSome or v?._isNone
     v
   else
     new Some(v)

--- a/src/property.coffee
+++ b/src/property.coffee
@@ -62,6 +62,8 @@ class PropertyDispatcher extends Dispatcher
 
 
 class Property extends Observable
+  _isProperty: true
+
   constructor: (desc, subscribe, handler) ->
     super(desc)
     assertFunction(subscribe)

--- a/src/reply.coffee
+++ b/src/reply.coffee
@@ -1,2 +1,2 @@
-Bacon.noMore = ["<no-more>"]
-Bacon.more = ["<more>"]
+Bacon.noMore = "<no-more>"
+Bacon.more = "<more>"

--- a/src/sample.coffee
+++ b/src/sample.coffee
@@ -15,7 +15,7 @@ Bacon.Property :: sampledBy = (sampler, combinator) ->
   thisSource = new Source(this, false, lazy)
   samplerSource = new Source(sampler, true, lazy)
   stream = Bacon.when([thisSource, samplerSource], combinator)
-  result = if sampler instanceof Property then stream.toProperty() else stream
+  result = if sampler?._isProperty then stream.toProperty() else stream
   withDesc(new Bacon.Desc(this, "sampledBy", [sampler, combinator]), result)
 
 Bacon.Property :: sample = (interval) ->
@@ -23,7 +23,7 @@ Bacon.Property :: sample = (interval) ->
     @sampledBy Bacon.interval(interval, {}))
 
 Bacon.Observable :: map = (p, args...) ->
-  if (p instanceof Property)
+  if (p?._isProperty)
     p.sampledBy(this, former)
   else
     convertArgsToFunction this, p, args, (f) ->

--- a/src/skipduplicates.coffee
+++ b/src/skipduplicates.coffee
@@ -5,7 +5,7 @@ Bacon.Observable :: skipDuplicates = (isEqual = (a, b) -> a == b) ->
     @withStateMachine None, (prev, event) ->
       unless event.hasValue()
         [prev, [event]]
-      else if event.isInitial() or prev == None or !isEqual(prev.get(), event.value())
+      else if event.isInitial() or prev?._isNone or !isEqual(prev.get(), event.value())
         [new Some(event.value()), [event]]
       else
         [prev, []])

--- a/src/source.coffee
+++ b/src/source.coffee
@@ -1,6 +1,8 @@
 # build-dependencies: _
 
 class Source
+  _isSource: true
+
   constructor: (@obs, @sync, @lazy = false) ->
     @queue = []
   subscribe: (sink) -> @obs.dispatcher.subscribe(sink)
@@ -34,15 +36,15 @@ class BufferingSource extends Source
   hasAtLeast: -> true
 
 Source.isTrigger = (s) ->
-  if s instanceof Source
+  if s?._isSource
     s.sync
   else
-    s instanceof EventStream
+    s?._isEventStream
 
 Source.fromObservable = (s) ->
-  if s instanceof Source
+  if s?._isSource
     s
-  else if s instanceof Property
+  else if s?._isProperty
     new Source(s, false)
   else
     new ConsumingSource(s, true)


### PR DESCRIPTION
As [mentioned](https://github.com/baconjs/bacon.js/issues/578) [many](https://github.com/baconjs/bacon.js/issues/522) [times](https://github.com/baconjs/bacon.js/issues/629) [over](https://github.com/baconjs/bacon.js/issues/296) Bacon uses `instanceof`, which does not play well with multiple JS execution contexts.

In our specific case we are testing our Bacon streams using [Jest](https://github.com/facebook/jest) which has its own module loader. This change would allow us to go back to upstream Bacon.

Someone made the point that because Bacon also has some shared global state, preventing complete "purity", we should not fix this. I disagree. With this out the way many simple problems (like our case) will be solved. This problem should be tackled in an iterative way, unless you want to leave it unsolved forever.