### PR TITLE
Stream transformer - "bufferingDebounce"

### DIFF
--- a/src/bufferingdebounce.js
+++ b/src/bufferingdebounce.js
@@ -1,0 +1,22 @@
+// build-dependencies: flatmaplatest, frombinder, once
+Bacon.EventStream.prototype.bufferingDebounce = function(delay, timeout) {
+    timeout = timeout || 10000;
+    return withDesc(new Bacon.Desc(this, "bufferingDebounce", [delay, timeout]), this.flatMapLatest((function(buffer, stamp) {
+        return function(value){
+            buffer.length === 0 && (stamp = Date.now());
+            buffer.push(value);
+            return (stamp + timeout < Date.now()) ? Bacon.once(buffer.splice(0)) : Bacon.fromBinder(function(sink) {
+                var timer = setTimeout(function() {
+                    sink(buffer.splice(0));
+                }, delay);
+                return clearTimeout.bind(undefined, timer);
+            });
+        }
+    })([])));
+};
+
+Bacon.Property.prototype.bufferingDebounce = function(delay, timeout) {
+    return this.delayChanges(new Bacon.Desc(this, "bufferingDebounce", [delay, timeout]), function(changes) {
+        return changes.bufferingDebounce(delay, timeout);
+    });
+};

--- a/src/main.js
+++ b/src/main.js
@@ -64,3 +64,4 @@
 // build-dependencies: try
 // build-dependencies: update
 // build-dependencies: zip
+// build-dependencies: bufferingdebounce


### PR DESCRIPTION
Adds the ability to "debounce" and buffer input values. The output value will consist of an array with all collected input values during "debounce".

This transformer may be useful in situations where you'd wish to hold processing while data keeps showing up in succession to create a "batch". The timeout is crucial to prevent buffer flood.

**bufferingDebounce** receives two args:
- **delay** - The debounce delay (in milliseconds). The period of time to wait after an input value was supplied before resetting the timer on the arrival of a new input value or delivering an output array with all buffered input values.
- **timeout** - The maximum time span (in milliseconds) after which an output value is produced even though **delay** never expires.
