### PR TITLE
Bind composite without Function::bind

### DIFF
--- a/src/compositeunsubscribe.js
+++ b/src/compositeunsubscribe.js
@@ -1,5 +1,5 @@
 function CompositeUnsubscribe(ss = []) {
-  this.unsubscribe = this.unsubscribe.bind(this);
+  this.unsubscribe = _.bind(this.unsubscribe, this);
   this.unsubscribed = false;
   this.subscriptions = [];
   this.starting = [];


### PR DESCRIPTION
While doing ES6 transformation, this slipped in. Breaks compatibility with IE8 unless a shim is loaded.