### PR TITLE
Run browser tests in Browserstack 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 node_js:
 - '0.10'
 - '0.12'
-- '4.0'
-- '4.1'
+- '4.2'
+- '5.0'
 before_install:
 - npm install -g npm@'>=2.11'
 - npm conf set strict-ssl false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,31 @@
 language: node_js
 sudo: false
 node_js:
-- '0.10'
-- '0.12'
-- '4.2'
-- '5.0'
+  - '0.10'
+  - '0.12'
+  - '4.2'
+  - '5.3'
 before_install:
-- npm install -g npm@'>=2.11'
-- npm conf set strict-ssl false
-after_install:
-- sudo npm install -g phantomjs grunt-cli
-before_script:
-- phantomjs --version
-script:
-- npm test
-- grunt readme && git diff --exit-code README.md
+  - npm install -g npm@'>=2.11'
+  - npm conf set strict-ssl false
 notifications:
-  flowdock: 3853ef33f6943539cbbed913648575be
+  flowdock: 3853ef33f6943539cbbed913648575beg
+script:
+  - npm test
+  - grunt readme && git diff --exit-code README.md
+env:
+  global:
+    - secure: VHyJgRz2G9C1gh+BW/ttoWOujZq+QogTdot6gdhvczB3PihZ9FFgglK0S3i4tCZFrfjBz/XMKiqF6tlQhoTQj6FD1ADSRaptel7Xv4qgcsVBffYpZS5g68gDzDG9BFOb6kes8sRJVA7Jf3OL+EhKAsvZ3e5SmHJ1SiCPdaVRSBk=
+    - secure: K11WcONU2Zptx/t8GTpE2S/Gjkmt4pVEQd9tv1AAqNWdB6/FnRWd4lCemvfeU8YiDkQSh1Pm8N116u4/m0nKxNML4GLp4PPqaVK7h7MdDndjsyaHOeDlekdGFmSWa628kulrnD1/inyJjIJKf9Z5vFiVKjVo4WGWrDb2KlUr8O0=
+    - secure: EzdZS4kE+Qr88RANdHGTiT9jfG5Cql2srthbkufeh3Py+tl1Zz+IIr2LUX2/l286xVAtbIUAwYHxlBmnvaZfI6gyq8fjZMCutNzf6l8XAxBxguyPIruJj7c+Fbor2hR0QScg60yOYznkTTpf0LtC4pSsTAN0vbxvPxa5i2SoWsg=
 branches:
   only:
-  - master
+    - master
+matrix:
+  fast_finish: true
+  include:
+    - env: TEST_SUITE=browserstack-status
+      node_js: '5.0'
+  allow_failures:
+    - env: TEST_SUITE=browserstack-status
+      node_js: '5.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,22 @@
 language: node_js
 sudo: false
-
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.0"
-  - "4.1"
-
+- '0.10'
+- '0.12'
+- '4.0'
+- '4.1'
 before_install:
-  - npm install -g npm@'>=2.11'
-  - npm conf set strict-ssl false
-
+- npm install -g npm@'>=2.11'
+- npm conf set strict-ssl false
 after_install:
-  - sudo npm install -g phantomjs grunt-cli
-
+- sudo npm install -g phantomjs grunt-cli
 before_script:
-  - phantomjs --version
-
+- phantomjs --version
 script:
-  - npm test
-  - grunt readme && git diff --exit-code README.md
-
+- npm test
+- grunt readme && git diff --exit-code README.md
 notifications:
   flowdock: 3853ef33f6943539cbbed913648575be
-
 branches:
   only:
-    - master
+  - master

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -87,7 +87,11 @@ module.exports = (grunt) ->
             resolve()
 
     commit = (callback) ->
-      if process.env.TRAVIS_COMMIT
+      if process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST != 'false'
+        exec = require('child_process').exec
+        exec("git rev-list --parents -n 1 #{process.env.TRAVIS_COMMIT}",
+          (error, stdout) -> callback(stdout.toString().split(' ')[2]))
+      else if process.env.TRAVIS_COMMIT
         callback(process.env.TRAVIS_COMMIT)
       else
         require('git-rev').long(callback)

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -26,7 +26,7 @@ setCommitStatus = (sha, state) ->
     token: process.env.GITHUB_TOKEN
 
   q =
-    user: 'lautis',
+    user: 'baconjs',
     repo: 'bacon.js',
     sha: sha,
     state: state

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -91,9 +91,9 @@ module.exports = (grunt) ->
       setCommitStatus(sha, 'pending')
         .then(browserstack(grunt))
         .then(
-          (output) ->
-            setCommitStatus(sha, 'success')
-          (error) ->
-            setCommitStatus(sha, 'failure')
-              .then -> throw error
-        ).then(done, -> done(3))
+          (output) -> setCommitStatus(sha, 'success')
+          (error) -> setCommitStatus(sha, 'failure').then(-> Promise.reject(error))
+        ).then(done, ->
+          grunt.log.error(error.message)
+          done(1)
+        )

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,3 +1,44 @@
+browserstack = (grunt) ->
+  log = (message) -> grunt.log.write(message)
+
+  exec = require('child_process').exec
+  ->
+    new Promise (resolve, reject) ->
+      child = exec './node_modules/.bin/browserstack-runner', (error, stdout, stderr) ->
+        if error
+          reject(error)
+        else
+          resolve(stdout.toString())
+      child.stdout.on('data', log)
+      child.stderr.on('data', log)
+
+setCommitStatus = (sha, state) ->
+  GitHub = require('github')
+  github = new GitHub
+    version: '3.0.0'
+    protocol: 'https',
+    timeout: 5000,
+    headers:
+      'user-agent': 'github-status-reporter'
+
+  github.authenticate
+    type: 'oauth'
+    token: process.env.GITHUB_TOKEN
+
+  q =
+    user: 'lautis',
+    repo: 'bacon.js',
+    sha: sha,
+    state: state
+    context: 'continous-integration/browserstack'
+
+  new Promise (resolve, reject) ->
+    github.statuses.create q, (error) ->
+      if error
+        reject(error)
+      else
+        resolve()
+
 module.exports = (grunt) ->
   grunt.initConfig
     clean:
@@ -41,3 +82,18 @@ module.exports = (grunt) ->
     readmedoc = require './readme-src.coffee'
     readmegen = require './readme/readme.coffee'
     fs.writeFileSync('README.md', readmegen readmedoc)
+
+  grunt.registerTask 'browserstack-status', 'Run BrowserStack tests and report status to GitHub', ->
+    done = @async()
+    git = require('git-rev')
+    git.long (sha) ->
+      grunt.log.write('SHA: ' + sha)
+      setCommitStatus(sha, 'pending')
+        .then(browserstack(grunt))
+        .then(
+          (output) ->
+            setCommitStatus(sha, 'success')
+          (error) ->
+            setCommitStatus(sha, 'failure')
+              .then -> throw error
+        ).then(done, -> done(3))

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -25,9 +25,11 @@ setCommitStatus = (sha, state) ->
     type: 'oauth'
     token: process.env.GITHUB_TOKEN
 
+  repo = (process.env.TRAVIS_REPO_SLUG || 'baconjs/bacon.js').split('/', 2)
+
   q =
-    user: 'baconjs',
-    repo: 'bacon.js',
+    user: repo[0],
+    repo: repo[1],
     sha: sha,
     state: state
     context: 'continous-integration/browserstack'

--- a/README.md
+++ b/README.md
@@ -1888,11 +1888,6 @@ I have personally used it Bacon.js with Chrome, Firefox, Safari, IE 6+, iPhone, 
 
 Automatically tested on each commit on modern browsers and IE6+.
 
-The full Bacon.js test suite is run on testling.ci with a wide range of browsers:
-
-[![browser support test report](http://ci.testling.com/baconjs/bacon.js.png)](http://ci.testling.com/baconjs/bacon.js)
-
-Results from those tests are quite unreliable, producing random failures, but the bottom line is that there are no outstanding compatibility issues.
 
 Node.js
 =======

--- a/README.md
+++ b/README.md
@@ -1886,7 +1886,7 @@ Bacon.js is not browser dependent, because it is not a UI library.
 
 I have personally used it Bacon.js with Chrome, Firefox, Safari, IE 6+, iPhone, iPad.
 
-Automatically tested on each commit on modern browsers and IE6+.
+Automatically tested on each commit on modern browsers.
 
 
 Node.js

--- a/browserstack.json
+++ b/browserstack.json
@@ -2,9 +2,7 @@
   "test_framework": "mocha",
   "test_path": "browsertest/mocha.runner.html",
   "browsers": [
-    "chrome_previous",
     "chrome_latest",
-    "firefox_previous",
     "firefox_latest",
     "safari_previous",
     "safari_latest",

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,0 +1,13 @@
+{
+    "test_framework": "mocha",
+    "test_path": "browsertest/mocha.runner.html",
+    "browsers": [
+      "chrome_previous",
+      "chrome_latest",
+      "firefox_previous",
+		"firefox_latest",
+      "safari_previous",
+		"safari_latest",
+		"ie_11"
+    ]
+}

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,13 +1,14 @@
 {
-    "test_framework": "mocha",
-    "test_path": "browsertest/mocha.runner.html",
-    "browsers": [
-      "chrome_previous",
-      "chrome_latest",
-      "firefox_previous",
-		"firefox_latest",
-      "safari_previous",
-		"safari_latest",
-		"ie_11"
-    ]
+  "test_framework": "mocha",
+  "test_path": "browsertest/mocha.runner.html",
+  "browsers": [
+    "chrome_previous",
+    "chrome_latest",
+    "firefox_previous",
+    "firefox_latest",
+    "safari_previous",
+    "safari_latest",
+    "ie_11",
+    "ie_10"
+  ]
 }

--- a/browsertest/mocha.runner.html
+++ b/browsertest/mocha.runner.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8" />
   <title>Mocha Tests</title>
   <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
   <script src="../node_modules/mocha/mocha.js"></script>
@@ -16,7 +17,7 @@
       } else {
         mocha.run();
       }
-    })
+    });
   </script>
 </head>
 <body>

--- a/browsertest/mocha.runner.html
+++ b/browsertest/mocha.runner.html
@@ -8,10 +8,6 @@
   <script>
     mocha.setup('bdd');
   </script>
-  <script>
-    if (location.hash === '#testem')
-      document.write('<script src="/testem.js"></'+'script>')
-  </script>
   <script src="bundle.js"></script>
   <script>
     $(function() {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bluebird": "^2",
     "bower-json": "^0.6.0",
     "browserify": "^11.2.0",
+    "browserstack-runner": "^0.3.8",
     "chai": "^3.3.0",
     "coffee-script": "^1.9.1",
     "coffeeify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "escodegen": "^1.6.1",
     "esprima": "^2.0.0",
     "estraverse": "^1.9.1",
+    "git-rev": "^0.2.1",
+    "github": "^0.2.4",
     "grunt": "0.4",
     "grunt-cli": "0.1.13",
     "grunt-coffeelint": "0.0.13",

--- a/package.json
+++ b/package.json
@@ -66,40 +66,6 @@
     "url": "https://github.com/baconjs/bacon.js.git"
   },
   "homepage": "https://github.com/baconjs/bacon.js",
-  "testling": {
-    "browsers": {
-      "ie": [
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      "ff": [
-        12,
-        17,
-        22
-      ],
-      "chrome": [
-        22
-      ],
-      "opera": [
-        12
-      ],
-      "safari": [
-        5.1,
-        6
-      ],
-      "iphone": [
-        6
-      ],
-      "ipad": [
-        6
-      ]
-    },
-    "harness": "mocha",
-    "files": "spec/CompatibilityTest.coffee"
-  },
   "scripts": {
     "test": "./runtests",
     "pre-publish": "grunt"

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1966,11 +1966,6 @@ I have personally used it Bacon.js with Chrome, Firefox, Safari, IE 6+, iPhone, 
 
 Automatically tested on each commit on modern browsers and IE6+.
 
-The full Bacon.js test suite is run on testling.ci with a wide range of browsers:
-
-[![browser support test report](http://ci.testling.com/baconjs/bacon.js.png)](http://ci.testling.com/baconjs/bacon.js)
-
-Results from those tests are quite unreliable, producing random failures, but the bottom line is that there are no outstanding compatibility issues.
 """
 
 doc.section "Node.js"

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1964,7 +1964,7 @@ Bacon.js is not browser dependent, because it is not a UI library.
 
 I have personally used it Bacon.js with Chrome, Firefox, Safari, IE 6+, iPhone, iPad.
 
-Automatically tested on each commit on modern browsers and IE6+.
+Automatically tested on each commit on modern browsers.
 
 """
 

--- a/runtests
+++ b/runtests
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -e
 ./node_modules/.bin/babel-node assemble-specs.js $@
-./node_modules/.bin/mocha --compilers coffee:coffee-script/register spec/BaconSpec.coffee
+
+if [ "${TEST_SUITE}" = "browserstack-status" ]; then
+  browsertest/browserify
+  ./node_modules/.bin/grunt browserstack-status
+else
+  ./node_modules/.bin/mocha --compilers coffee:coffee-script/register spec/BaconSpec.coffee
+fi

--- a/spec/CompatibilityTest.coffee
+++ b/spec/CompatibilityTest.coffee
@@ -1,4 +1,0 @@
-# A pruned version of BaconSpec, just to see if it runs nicer in Testling.CI
-describe "Just testing", ->
-  it "should always work", ->
-    console.log "hooray"

--- a/spec/specs/once.coffee
+++ b/spec/specs/once.coffee
@@ -14,7 +14,7 @@ describe "Bacon.once", ->
   it "Responds synchronously", ->
     values = []
     s = Bacon.once(1)
-    s.onValue(values.push.bind(values))
+    s.onValue((value) => values.push(value))
     expect(values).to.deep.equal([1])
-    s.onValue(values.push.bind(values))
+    s.onValue((value) => values.push(value))
     expect(values).to.deep.equal([1])

--- a/spec/specs/packagemanagement.coffee
+++ b/spec/specs/packagemanagement.coffee
@@ -1,6 +1,8 @@
 describe "Package management", ->
+  return unless typeof window == 'undefined'
+
   fs = require("fs")
-  verifyJson = (fn) -> 
+  verifyJson = (fn) ->
     JSON.parse(fs.readFileSync("bower.json", "utf-8"))
   it "NPM", ->
     verifyJson "package.json"
@@ -10,4 +12,3 @@ describe "Package management", ->
     bowerJson = require('bower-json')
     json = verifyJson "bower.json"
     bowerJson.validate(json)
-


### PR DESCRIPTION
Since Testling isn't working ("Testling is currently not working. We're working to fix it!"), let's try BrowserStack.


TODO:

- [x] enable open source plan for BrowserStack
- [x] sane test triggering: run browser tests only once per push
- [x] preferably report success/failure with separate commit status in GitHub
- [x] fix old IE builds
- [x] replace Testling build matrix image with BrowserStack link
