### PR TITLE
Use lodash 4 to generate readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     }
   ],
   "license": "MIT",
-  "dependencies": {
-    "lodash": "^3.10.0"	
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel": "^5.8.23",
     "benchmark": "1.0.0",

--- a/readme/common.coffee
+++ b/readme/common.coffee
@@ -43,15 +43,15 @@ findFunctionAnchor = (text, anchors) ->
   m = text.toLowerCase().match /^(\w+)\.(\w+)/
   if m?
     fnAnchor = m[1] + "-" + m[2]
-  if fnAnchor? && _.contains anchors, fnAnchor
+  if fnAnchor? && _.includes anchors, fnAnchor
     fnAnchor
 
 findAnchorByNeedle = (text, anchors) ->
   anchorNeedle = text.toLowerCase().replace(".", "-").replace(/[^a-z\-]/g, "")
 
-  if _.contains anchors, anchorNeedle
+  if _.includes anchors, anchorNeedle
     anchorNeedle
-  else if _.contains ["subscribe", "f"], anchorNeedle
+  else if _.includes ["subscribe", "f"], anchorNeedle
     undefined
   else
     possibleAnchors = _.filter anchors, (anchor) ->


### PR DESCRIPTION
Use _.includes instead of _.contains to generate readme. This removes the lodash runtime dependency which was added in #661.