### PR TITLE
Do not mutate the given array in combineAsArray

### DIFF
--- a/spec/specs/combine.coffee
+++ b/spec/specs/combine.coffee
@@ -41,6 +41,16 @@ describe "Property.combine", ->
         src = series(1, ["same", error()])
         Bacon.combineAsArray(src, src)
       [["same", "same"], error()])
+
+  it "does not mutate given array", ->
+    lol = Bacon.once("lol")
+    bal = "bal"
+    streams = [lol, bal]
+    Bacon.combineAsArray(streams)
+    expect(streams.length).to.equal(2)
+    expect(streams[0]).to.equal(lol)
+    expect(streams[1]).to.equal(bal)
+
   it "toString", ->
     expect(Bacon.constant(1).combine(Bacon.constant(2), (->)).toString()).to.equal("Bacon.constant(1).combine(Bacon.constant(2),function)")
   describe "with random methods on Array.prototype", ->

--- a/src/combine.js
+++ b/src/combine.js
@@ -3,7 +3,7 @@
 // build-dependencies: when
 
 Bacon.combineAsArray = function() {
-  var streams = argumentsToObservables(arguments);
+  var streams = argumentsToObservables(arguments).slice();
   for (var index = 0, stream; index < streams.length; index++) {
     stream = streams[index];
     if (!isObservable(stream)) {


### PR DESCRIPTION
The current implementation mutates the given input argument array if it contains non-observable values, e.g. `combinAsArray([Bacon.once("foo"), "bar"])`. This caused problems when we were using `combineAsArray` for [observable React element children](https://github.com/calmm-js/bacon.react.base/blob/5c5051f10f6fd014bfe703ad27b616248f06d746/src/bacon.react.base.js#L87-L91).

This PR prevents mutation even if the input array contains mixed values and observables.