### PR TITLE
README: fix typo in observable.withStateMachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,8 +824,8 @@ properties with array value. The result is a Property.
 [`observable.withStateMachine(initState, f)`](#observable-withstatemachine "observable.withStateMachine(initState, f)") lets you run a state machine
 on an observable. Give it an initial state object and a state
 transformation function that processes each incoming event and
-returns and array containing the next state and an array of output
-events. Here's an an example, where we calculate the total sum of all
+returns an array containing the next state and an array of output
+events. Here's an example where we calculate the total sum of all
 numbers in the stream and output the value on stream end:
 
 ```js

--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -845,8 +845,8 @@ doc.fn "observable.withStateMachine(initState, f)", """
 lets you run a state machine
 on an observable. Give it an initial state object and a state
 transformation function that processes each incoming event and
-returns and array containing the next state and an array of output
-events. Here's an an example, where we calculate the total sum of all
+returns an array containing the next state and an array of output
+events. Here's an example where we calculate the total sum of all
 numbers in the stream and output the value on stream end:
 
 ```js


### PR DESCRIPTION
This fix some typo in `observable.withStateMachine` documentation