### PR TITLE
Fix .toPromise when the observable ends without values

### DIFF
--- a/src/topromise.js
+++ b/src/topromise.js
@@ -15,6 +15,7 @@ Observable.prototype.firstToPromise = function (PromiseCtr) {
     this.subscribe((event) => {
       if (event.hasValue()) { resolve(event.value()); }
       if (event.isError()) { reject(event.error); }
+      if (event.isEnd()) { resolve(); }
       // One event is enough
       return Bacon.noMore;
     }));


### PR DESCRIPTION
The promise returned by `.toPromise()` never get's resolved (nor rejected) if the observable ends without emitting any value or error.

```javascript
const Bacon = require('baconjs');

const stream = Bacon.fromBinder((sink) => {
  setTimeout(() => sink(Bacon.End()), 1000);
});

stream.toPromise().then(() => {
  console.log('this line never runs');
});
```