### PR TITLE
add throttleImmediate

### DIFF
--- a/spec/specs/throttle.coffee
+++ b/spec/specs/throttle.coffee
@@ -7,6 +7,7 @@ expect = require("chai").expect
   expectStreamTimings,
   expectPropertyEvents,
   error,
+  semiunstable,
   lessThan,
   map,
   fromArray
@@ -28,6 +29,22 @@ describe "EventStream.throttle(delay)", ->
   it "toString", ->
     expect(Bacon.never().throttle(1).toString()).to.equal("Bacon.never().throttle(1)")
 
+describe "EventStream.throttleImmediate(delay)", ->
+  describe "outputs first event immediately, then ignores events for given amount of milliseconds", ->
+    expectStreamTimings(
+      -> series(2, [1, 2, 3, 4]).throttleImmediate(t(3))
+      [[2, 1], [6, 3], [11, 4]], semiunstable) # why 11?
+  describe "works with synchronous source", ->
+    expectStreamEvents(
+      -> fromArray([1, 2, 3, 4]).throttleImmediate(t(3))
+      [1, 4], semiunstable)
+  describe "does not emit double events with synchronous source", ->
+    expectStreamEvents(
+      -> fromArray([1]).throttleImmediate(t(1))
+      [1], semiunstable)
+  it "toString", ->
+    expect(Bacon.never().throttleImmediate(1).toString()).to.equal("Bacon.never().throttleImmediate(1)")
+
 describe "Property.throttle", ->
   describe "throttles changes, but not initial value", ->
     expectPropertyEvents(
@@ -39,3 +56,15 @@ describe "Property.throttle", ->
       [1])
   it "toString", ->
     expect(Bacon.constant(0).throttle(1).toString()).to.equal("Bacon.constant(0).throttle(1)")
+
+describe "Property.throttleImmediate", ->
+  describe "throttles changes, but not initial value", ->
+    expectPropertyEvents(
+      -> series(1, [1,2,3]).toProperty(0).throttleImmediate(t(4))
+      [0,3], semiunstable)
+  describe "works with Bacon.once", ->
+    expectPropertyEvents(
+      -> once(1).toProperty().throttleImmediate(1)
+      [1], semiunstable)
+  it "toString", ->
+    expect(Bacon.constant(0).throttleImmediate(1).toString()).to.equal("Bacon.constant(0).throttleImmediate(1)")

--- a/spec/specs/throttle.coffee
+++ b/spec/specs/throttle.coffee
@@ -33,7 +33,7 @@ describe "EventStream.throttleImmediate(delay)", ->
   describe "outputs first event immediately, then ignores events for given amount of milliseconds", ->
     expectStreamTimings(
       -> series(2, [1, 2, 3, 4]).throttleImmediate(t(3))
-      [[2, 1], [6, 3], [11, 4]], semiunstable) # why 11?
+      [[2, 1], [5, 2], [8, 3], [11, 4]], semiunstable)
   describe "works with synchronous source", ->
     expectStreamEvents(
       -> fromArray([1, 2, 3, 4]).throttleImmediate(t(3))

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -3,7 +3,22 @@ import "./delaychanges";
 import "./map";
 import Observable from "./observable";
 import { Desc } from "./describe";
+import Bacon from "./core";
 
 Observable.prototype.throttle = function (delay) {
-  return this.delayChanges(new Desc(this, "throttle", [delay]), (changes) => changes.bufferWithTime(delay).map((values) => values[values.length - 1]));
+  return this.delayChanges(new Desc(this, "throttle", [delay]), (changes) => 
+    changes
+      .bufferWithTime(delay)
+      .map((values) => values[values.length - 1]));
+};
+Observable.prototype.throttleImmediate = function (delay) {
+  return this.delayChanges(new Desc(this, "throttleImmediate", [delay]), (changes) => 
+    Bacon.mergeAll(
+      changes.debounceImmediate(delay),
+      changes.debounce(delay)
+    )
+    /*changes.flatMapFirst(value =>
+      Bacon.once(value).concat(Bacon.later(delay).filter(false))
+    )*/
+  );
 };


### PR DESCRIPTION
Created tests for #702 

Tried to borrow from the debounceImmediate implementation. Still searching for better solution.

@semmel merging creates duplicates as expected :/