### PR TITLE
Fix typo

### DIFF
--- a/readme-src.coffee
+++ b/readme-src.coffee
@@ -1873,7 +1873,7 @@ latter is for observable properties that have the concept of "current value".
 
 Also, there are no "cold observables", which
 means also that all EventStreams and Properties are consistent among subscribers:
-when as event occurs, all subscribers will observe the same event. If you're
+when an event occurs, all subscribers will observe the same event. If you're
 experienced with RxJs, you've probably bumped into some wtf's related to cold
 observables and inconsistent output from streams constructed using scan and startWith.
 None of that will happen with bacon.js.


### PR DESCRIPTION
I wasn't able to get the `npm run readme` task to work locally, so this change just updates the source and whenever the readme is next generated and pushed it will have the correction.