### PR TITLE
Make .flatScan work seedless

### DIFF
--- a/src/flatscan.js
+++ b/src/flatscan.js
@@ -4,9 +4,22 @@ import './doaction'
 import { makeObservable } from "./flatmap_"
 import EventStream from "./eventstream";
 // TODO: toString test, Desc
-EventStream.prototype.flatScan = function(seed, f) {
-  let current = seed
+Bacon.EventStream.prototype.flatScan = function (seed, f) {
+  var current;
+  var isSeeded = false;
+  
+  if (typeof seed === "function") {
+    return this.flatMapConcat(function (next) {
+      return (isSeeded ? makeObservable(seed(current, next)) : makeObservable(next))
+      .doAction(function (updated) {
+        isSeeded = true;
+        return current = updated;
+      });
+    }).toProperty();
+  }
+  
+  current = seed;
   return this.flatMapConcat(next =>
     makeObservable(f(current, next)).doAction(updated => current = updated)
-  ).toProperty(seed)
-}
+  ).toProperty(seed);
+};

--- a/src/flatscan.ts
+++ b/src/flatscan.ts
@@ -4,9 +4,23 @@ import { Desc } from "./describe";
 import { Function2 } from "./types";
 
 /** @hidden */
-export function flatScan<In, Out>(src: Observable<In>, seed: Out, f: Function2<Out, In, Observable<Out> | Out>): Property<Out> {
-  let current = seed
+export function flatScan<In, Out>(src: Observable<In>, seed: any | Function2<Out, In, Observable<Out> | Out>, f?: Function2<Out, In, Observable<Out> | Out>): Property<Out> {
+  let current: Out;
+  let isSeeded = false;
+
+  if (typeof seed === "function") {
+    return src.flatMapConcat(function (next: In) {
+      return (isSeeded ? makeObservable(seed(current, next)) : makeObservable(next))
+      .doAction(function (updated) {
+        isSeeded = true;
+        return current = updated;
+      });
+    }).toProperty();
+  }
+
+  current = seed;
   return src.flatMapConcat((next: In) =>
+      // @ts-ignore: TS2722 Cannot invoke an object which is possibly 'undefined'. Cause it's optional!
     makeObservable(f(current, next)).doAction(updated => current = updated)
   ).toProperty().startWith(seed).withDesc(new Desc(src, "flatScan", [seed, f]))
 }

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1400,7 +1400,7 @@ export class EventStream<V> extends Observable<V> {
    * @param f transition function from previous state and new value to next state
    * @typeparam V2 state and result type
    */
-  flatScan<V2>(seed: V2, f: Function2<V2, V, Observable<V2>>): Property<V2> {
+  flatScan<V2>(seed: V2 | Function2<V2, V, Observable<V2>>, f?: Function2<V2, V, Observable<V2>>): Property<V2> {
     return <any>flatScan(this, seed, f)
   }
 

--- a/test/flatscan.ts
+++ b/test/flatscan.ts
@@ -10,6 +10,12 @@ describe("EventStream.flatScan", function() {
       [0, 1, 3, error(), 6])
   );
 
+  describe.skip("beginning with the first source value successive values are accumulated values using the accumulator function which returns a stream of updated values", () =>
+    expectPropertyEvents(
+      () => series(1, [1, 2, error(), 3]).flatScan(addAsync(1)),
+      [1, 3, error(), 6])
+  );
+
   describe("Serializes updates even when they occur while performing previous update", () =>
     expectPropertyEvents(
       () => series(1, [1, 2, error(), 3]).flatScan(0, addAsync(5)),

--- a/types/flatscan.d.ts
+++ b/types/flatscan.d.ts
@@ -1,4 +1,4 @@
 import { Observable, Property } from "./observable";
 import { Function2 } from "./types";
 /** @hidden */
-export declare function flatScan<In, Out>(src: Observable<In>, seed: Out, f: Function2<Out, In, Observable<Out> | Out>): Property<Out>;
+export declare function flatScan<In, Out>(src: Observable<In>, seed: any | Function2<Out, In, Observable<Out> | Out>, f?: Function2<Out, In, Observable<Out> | Out>): Property<Out>;

--- a/types/observable.d.ts
+++ b/types/observable.d.ts
@@ -1068,7 +1068,7 @@ export declare class EventStream<V> extends Observable<V> {
      * @param f transition function from previous state and new value to next state
      * @typeparam V2 state and result type
      */
-    flatScan<V2>(seed: V2, f: Function2<V2, V, Observable<V2>>): Property<V2>;
+    flatScan<V2>(seed: V2 | Function2<V2, V, Observable<V2>>, f?: Function2<V2, V, Observable<V2>>): Property<V2>;
     /**
      Groups stream events to new streams by `keyF`. Optional `limitF` can be provided to limit grouped
      stream life. Stream transformed by `limitF` is passed on if provided. `limitF` gets grouped stream


### PR DESCRIPTION
If just the reducer function is given, the first value of the source stream will be passed as initial event of the resulting Property and used as the left argument when the reducer is first invoked on the second source event. 

I've found this useful to save meaningless lines of code. It should be easy understand because JS users are familiar with `Array.reduce` where the seed value is also optional. It should also be 100% non-breaking.

```javascript
Bacon.fromArray([10, 20]).flatScan((a, b) => a + b).log();
// --> 10, 30
```
If you are in favour of this change, perhaps `.scan` should be extended as well.

#### Remarks:
* I've found it very difficult to please the TypeScript's type checking. Because the first parameter to `.flatScan` is mow "multi-morphic" (i.e. a value or a function). Which IMO is naturally for dynamic JavaScript however TypeScript makes it really hard to enable this at all?
* I've not updated the documentation yet.