### PR TITLE
Allow "any" as Sink return type

### DIFF
--- a/src/reply.ts
+++ b/src/reply.ts
@@ -2,7 +2,7 @@
  * Return type for various [Sink](#sink) functions. Indicates whether or not the sink
  * desires more input from its source. See [`Bacon.fromBinder`](#frombinder) for example.
  */
-export type Reply = "<no-more>" | undefined | void
+export type Reply = "<no-more>" | any
 
 /**
  * Reply for "more data, please".

--- a/types/reply.d.ts
+++ b/types/reply.d.ts
@@ -2,7 +2,7 @@
  * Return type for various [Sink](#sink) functions. Indicates whether or not the sink
  * desires more input from its source. See [`Bacon.fromBinder`](#frombinder) for example.
  */
-export declare type Reply = "<no-more>" | undefined | void;
+export declare type Reply = "<no-more>" | any;
 /**
  * Reply for "more data, please".
  */


### PR DESCRIPTION
This allows one to write eg. myStream.onValue(v => myWritable.write(v)) instead of myStream.onValue(v => { myWritable.write(v) })