### PR TITLE
Merge groupBy signatures

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -464,9 +464,7 @@ Bacon.sequentially(2, events)
 ```
 
    */
-  abstract groupBy(keyF: Function1<V, string>, limitF?: GroupTransformer<V, V>): Observable<EventStream<V>>
-
-  abstract groupBy<V2>(keyF: Function1<V, string>, limitF: GroupTransformer<V, V2>): Observable<EventStream<V2>>
+  abstract groupBy<V2 = V>(keyF: Function1<V, string>, limitF?: GroupTransformer<V, V2>): Observable<EventStream<V2>>
 
   /**
 Pauses and buffers the event stream if last event in valve is truthy.
@@ -1107,11 +1105,7 @@ export class Property<V> extends Observable<V> {
    ```
 
    */
-  groupBy(keyF: Function1<V, string>, limitF?: GroupTransformer<V, V>): Property<EventStream<V>>
-
-  groupBy<V2>(keyF: Function1<V, string>, limitF: GroupTransformer<V, V2>): Property<EventStream<V2>>
-
-  groupBy<V2>(keyF: Function1<V, string>, limitF: GroupTransformer<V, V2>): Property<EventStream<V2>> {
+  groupBy<V2 = V>(keyF: Function1<V, string>, limitF?: GroupTransformer<V, V2>): Property<EventStream<V2>> {
     return <any>groupBy<V, V2>(this, keyF, limitF)
   }
 
@@ -1458,11 +1452,7 @@ export class EventStream<V> extends Observable<V> {
    ```
 
    */
-  groupBy(keyF: Function1<V, string>, limitF?: GroupTransformer<V, V>): EventStream<EventStream<V>>
-
-  groupBy<V2>(keyF: Function1<V, string>, limitF: GroupTransformer<V, V2>): EventStream<EventStream<V2>>
-
-  groupBy<V2>(keyF: Function1<V, string>, limitF: GroupTransformer<V, V2>): EventStream<EventStream<V2>> {
+  groupBy<V2 = V>(keyF: Function1<V, string>, limitF?: GroupTransformer<V, V2>): EventStream<EventStream<V2>> {
     return <any>groupBy(this, keyF, limitF)
   }
 


### PR DESCRIPTION
This should keep the API same but it has a performance benefit: the
non-type-parameter version of `groupBy` by itself caused `tsc` to
use over 6gb of memory and take 10x longer time on a real world
codebase.