### PR TITLE
Optimize concat and merge

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -164,6 +164,7 @@ events from `other`. This means too that events from `other`,
 occurring before the end of this observable will not be included in the result
 stream/property.
    */
+  abstract concat(other: Observable<V>): Observable<V>
   abstract concat<V2>(other: Observable<V2>): Observable<V | V2>
   /**
 Throttles stream/property by given amount
@@ -987,8 +988,10 @@ export class Property<V> extends Observable<V> {
    occurring before the end of this property will not be included in the result
    stream/property.
    */
-  concat<V2>(other: Observable<V2>): Property<V | V2> {
-    return addPropertyInitValueToStream<V | V2>(this as Property<V | V2>, this.changes().concat(other))
+  concat(other: Observable<V>): Property<V>
+  concat<V2>(other: Observable<V2>): Property<V | V2>
+  concat(other: Observable<any>): Property<any> {
+    return addPropertyInitValueToStream<any>(this as Property<any>, this.changes().concat(other))
   }
 
   /** @internal */
@@ -1339,7 +1342,9 @@ export class EventStream<V> extends Observable<V> {
    occurring before the end of this observable will not be included in the result
    stream/property.
    */
-  concat<V2>(other: Observable<V2>, options?: EventStreamOptions): EventStream<V | V2> {
+  concat(other: Observable<V>, options?: EventStreamOptions): EventStream<V>
+  concat<V2>(other: Observable<V2>, options?: EventStreamOptions): EventStream<V | V2>
+  concat(other: Observable<any>, options?: EventStreamOptions): EventStream<any> {
     return concatE(this, other, options)
   }
   /** @hidden */

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1472,9 +1472,11 @@ export class EventStream<V> extends Observable<V> {
   /**
    Merges two streams into one stream that delivers events from both
    */
-  merge<V2>(other: EventStream<V2>): EventStream<V  | V2> {
+  merge(other: EventStream<V>): EventStream<V>
+  merge<V2>(other: EventStream<V2>): EventStream<V | V2>
+  merge(other: EventStream<any>): EventStream<any> {
     assertEventStream(other)
-    return mergeAll<V | V2>(this as EventStream<V | V2>, other as EventStream<V | V2>).withDesc(new Desc(this, "merge", [other]));
+    return mergeAll<any>(this as EventStream<any>, other as EventStream<any>).withDesc(new Desc(this, "merge", [other]));
   }
 
   /**


### PR DESCRIPTION
These changes avoid creating new union types for `concat` and `merge` return values when they are not needed. Before `sampledBy` optimization, these changes were enough to drop compile time in a real world project from 160s to 40s and `tsc` memory usage from 6.5gb to roughly 2gb.