### PR TITLE
docs: Fix simple typo, subcribing -> subscribing

### DIFF
--- a/dist/Bacon.js
+++ b/dist/Bacon.js
@@ -2227,7 +2227,7 @@ function concatE(left, right, options) {
     }, undefined, options);
 }
 /**
- Concatenates given array of EventStreams or Properties. Works by subcribing to the first source, and listeing to that
+ Concatenates given array of EventStreams or Properties. Works by subscribing to the first source, and listeing to that
  until it ends. Then repeatedly subscribes to the next source, until all sources have ended.
 
  See [`concat`](#observable-concat)

--- a/dist/Bacon.js
+++ b/dist/Bacon.js
@@ -2227,7 +2227,7 @@ function concatE(left, right, options) {
     }, undefined, options);
 }
 /**
- Concatenates given array of EventStreams or Properties. Works by subscribing to the first source, and listeing to that
+ Concatenates given array of EventStreams or Properties. Works by subcribing to the first source, and listeing to that
  until it ends. Then repeatedly subscribes to the next source, until all sources have ended.
 
  See [`concat`](#observable-concat)

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -27,7 +27,7 @@ export function concatE<V, V2>(left: EventStream<V>, right: Observable<V2>, opti
 }
 
 /**
- Concatenates given array of EventStreams or Properties. Works by subcribing to the first source, and listeing to that
+ Concatenates given array of EventStreams or Properties. Works by subscribing to the first source, and listeing to that
  until it ends. Then repeatedly subscribes to the next source, until all sources have ended.
 
  See [`concat`](#observable-concat)


### PR DESCRIPTION
There is a small typo in dist/Bacon.js.

Should read `subscribing` rather than `subcribing`.

