### PR TITLE
Fix TS-generated invalid ES6 constructor call in firstToPromise()

### DIFF
--- a/src/topromise.ts
+++ b/src/topromise.ts
@@ -8,22 +8,25 @@ declare var Promise: any
 
 /** @hidden */
 export function firstToPromise<V>(src: Observable<V>, PromiseCtr: Function | undefined): Promise<V> {
-  // Can't do in the global scope, as shim can be applied after Bacon is loaded.
-  if (typeof PromiseCtr !== "function") {
-    if (typeof Promise === "function") {
-      PromiseCtr = (f: Function) => new Promise(f);
-    } else {
-      throw new Exception("There isn't default Promise, use shim or parameter");
-    }
-  }
+  const
+    generator = (resolve: ((v: V) => {}), reject: ((e: any) => {})) =>
+      src.subscribe((event) => {
+        if (hasValue(event)) { resolve(event.value); }
+        if (isError(event)) { reject(event.error); }
+        // One event is enough
+        return noMore;
+      });
 
-  return new (<any>PromiseCtr)((resolve: ((v: V) => {}), reject: ((e: any) => {})) =>
-    src.subscribe((event) => {
-      if (hasValue(event)) { resolve(event.value); }
-      if (isError(event)) { reject(event.error); }
-      // One event is enough
-      return noMore;
-    }));
+  // Can't do in the global scope, as shim can be applied after Bacon is loaded.
+  if (typeof PromiseCtr === "function") {
+    return new (<any>PromiseCtr)(generator);
+  }
+  else if (typeof Promise === "function") {
+    return new Promise(generator);
+  }
+  else {
+    throw new Exception("There isn't default Promise, use shim or parameter");
+  }
 };
 
 /** @hidden */


### PR DESCRIPTION
This fixes the ES6 implementation of `.firstToPromise()` in `dist/Bacon.mjs`.
E.g. in Node.js 12 with the latest (v3.0.15) version of Bacon:
 
```javascript
import('./node_modules/baconjs/dist/Bacon.mjs').then(m => {globalThis.B = m;});
B.once(8).firstToPromise().then(console.log, console.warn);

// -> Uncaught TypeError: PromiseCtr is not a constructor
// at firstToPromise (file:///.../baconjs/dist/Bacon.mjs:2989:12)
```