### PR TITLE
Converge esm imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,19 @@
 {
   "name": "baconjs",
-  "version": "3.0.13",
+  "version": "3.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@rollup/plugin-replace": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
+      "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "magic-string": "^0.25.5"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.9.tgz",
@@ -108,7 +118,8 @@
     "@types/node": {
       "version": "14.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "9.0.0",
@@ -2202,6 +2213,15 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -3452,6 +3472,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     }
   ],
   "license": "MIT",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
-    "@types/node": "^14.6.0",
+    "@rollup/plugin-replace": "^2.3.3",
     "@types/bluebird": "^3.5.26",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^7.0.2",
+    "@types/node": "^14.6.0",
     "@types/sinon": "^9.0.0",
     "@types/zen-observable": "^0.8.0",
     "benchmark": "^2",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,10 @@
     "typedoc": "typedoc --out docs --ignoreCompilerErrors src --mode file --excludeNotExported"
   },
   "main": "dist/Bacon.js",
+  "module": "./dist/Bacon.mjs",
+  "exports": {
+    "import": "./dist/Bacon.mjs",
+    "require": "./dist/Bacon.js"
+  },
   "types": "types/bacon.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:es6-modules": "if node --experimental-modules -e ''; then mocha -r esm test/es6-modules/*.js; fi",
     "perftest": "performance/PerformanceTest.ts",
     "lint": "echo no linter at the moment",
-    "dist": "./scripts/dist",
+    "dist": "DIST_VERSION=$npm_package_version ./scripts/dist",
     "prepublish": "npm run lint && npm run dist",
     "version": "3.0.16",
     "browsertest-bundle": "browsertest/browserify",

--- a/scripts/assemble.js
+++ b/scripts/assemble.js
@@ -4,6 +4,7 @@ var fs = require("fs");
 var path = require("path");
 var rollup = require("rollup").rollup;
 var typescriptPlugin = require("rollup-plugin-typescript2");
+var replace = require('@rollup/plugin-replace');
 var Terser = require("terser");
 
 var uglifyjs = require("uglify-js");
@@ -41,6 +42,11 @@ function main(options) {
       useTsconfigDeclarationDir: true
     })
   ];
+  
+  if (process.env.DIST_VERSION) {
+    plugins.push(replace({__version__: process.env.DIST_VERSION}));
+    pluginsTargetingES6.push(replace({__version__: process.env.DIST_VERSION}));
+  }
 
   // sequence of transpiling to ES5 and then to ES6
   rollup({

--- a/scripts/dist
+++ b/scripts/dist
@@ -6,4 +6,5 @@ node scripts/assemble.js $@
 if [ ! -z $DIST_VERSION ]; then
   echo "Setting version info to dist/*.js files"
   sed -i "" 's/<version>/'$DIST_VERSION'/' dist/*.js
+  sed -i "" 's/<version>/'$DIST_VERSION'/' dist/*.mjs
 fi

--- a/scripts/dist
+++ b/scripts/dist
@@ -2,9 +2,3 @@
 set -e
 echo "building dist..."
 node scripts/assemble.js $@
-
-if [ ! -z $DIST_VERSION ]; then
-  echo "Setting version info to dist/*.js files"
-  sed -i "" 's/<version>/'$DIST_VERSION'/' dist/*.js
-  sed -i "" 's/<version>/'$DIST_VERSION'/' dist/*.mjs
-fi

--- a/src/bacon.ts
+++ b/src/bacon.ts
@@ -3,7 +3,7 @@ import "./esobservable";
 /**
  *  Bacon.js version as string
  */
-export const version = '<version>'
+export const version = '__version__'
 
 export * from "./update"
 export { when, Pattern, Pattern1, Pattern2, Pattern3, Pattern4, Pattern5, Pattern6 } from "./when"

--- a/test/es6-modules/es6-module.js
+++ b/test/es6-modules/es6-module.js
@@ -1,5 +1,6 @@
 import * as Bacon from '../../dist/Bacon.mjs';
 import { expect } from "chai";
+const pkg = require('../../package.json');
 
 describe("ES6 module", function() {
   it("Passes smoke test", () => {
@@ -15,5 +16,8 @@ describe("ES6 module", function() {
   })
   it("firstToPromise", () => {
     Bacon.once(1).firstToPromise()
+  })
+  it("has the version number", () => {
+    expect(Bacon.version).to.equal(pkg.version);
   })
 });


### PR DESCRIPTION
Fixes #774 

I left out the Node.js import test because it would require creating a new npm project and `npm install`ing `baconjs`.

Here is the code anyway:
```javascript
// file: testBareImport.mjs
import * as Bacon from 'baconjs';
import pkg from "chai";
const { assert } = pkg;

describe("Bare ES6 import in Node.js", function() {
	it("passes smoke test", () =>
		Bacon.sequentially(10, [1, 2, 3])
		.map(x => x * x)
		.reduce(0, (acc, y) => acc +y)
		.toPromise()
		.then(sum => assert.equal(sum, 14))
	);
	it ("imports the ES6 classes", () => {
		// ES6 class constructors require 'new'
		// So while with ES5 constructor functions calls without 'new'
		// do not throw, calls to ES6 constructors throw TypeError
		assert.throws(() => {Bacon.Error("woo");}, TypeError);
	});
});
```

Execute with `$mocha testBareImport.mjs`.