### PR TITLE
feat: Add support for `moduleResolution: bundler`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "baconjs",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   "module": "./dist/Bacon.mjs",
   "exports": {
     "import": "./dist/Bacon.mjs",
+    "types": "./types/bacon.d.ts",
     "require": "./dist/Bacon.js"
   },
   "types": "types/bacon.d.ts"


### PR DESCRIPTION
To allow using bacon.js with the `moduleResolution: bundler` in a `.tsconfig` we need to specify the types path as part of the `exports` object.

Source: https://github.com/microsoft/TypeScript/pull/51669