### PR TITLE
TypePredicate filter

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -10,7 +10,9 @@ import {
   Unsub,
   VoidSink,
   Function1,
-  Function2, Function0
+  Function2, Function0,
+  ObservableWithParam,
+  TypePredicate
 } from "./types"
 import { default as withStateMachine, StateF } from "./withstatemachine";
 import { default as skipDuplicates, Equals } from "./skipduplicates";
@@ -331,6 +333,9 @@ Same as filtering with a function that always returns false.
   errors(): this {
     return this.filter(x => false).withDesc(new Desc(this, "errors"))
   }
+
+  filter<S extends V>(f: TypePredicate<S>):  ObservableWithParam<this, S>
+  filter(f: Predicate<V> | boolean | Property<boolean>): this
   /**
 Filters values using given predicate function.
 Instead of a function, you can use a constant value (`true` to include all, `false` to exclude all).
@@ -339,7 +344,7 @@ You can also filter values based on the value of a
 property. Event will be included in output [if and only if](http://en.wikipedia.org/wiki/If_and_only_if) the property holds `true`
 at the time of the event.
    */
-  filter(f: Predicate<V> | boolean | Property<boolean>): this {
+  filter(f: Predicate<V> | boolean | Property<boolean>): any {
     return <any>filter(this, f)
   }
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
+import Bus from "./bus";
 import { Event } from "./event"
-import { EventStream } from "./observable";
+import { EventStream, Property, Observable } from "./observable";
 import { more, Reply } from "./reply";
 
 export type Sink<V> = (value: V) => Reply
@@ -22,3 +23,5 @@ export type Function3<T1, T2, T3, R> = (t1: T1, t2: T2, t3: T3) => R;
 export type Function4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4) => R;
 export type Function5<T1, T2, T3, T4, T5, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => R;
 export type Function6<T1, T2, T3, T4, T5, T6, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => R;
+export type ObservableWithParam<T extends Observable<any>, P> = T extends Bus<any>|EventStream<any> ? EventStream<P> : T extends Property<any> ? Property<P> : Observable<P>
+export type TypePredicate<S> = (v: any) => v is S


### PR DESCRIPTION
It is often needed to `filter()` a stream in such a way that only certain event sub-types are retained. Presently, the `filter()` method always returns the same stream type `EventStream<T> -> EventStream<T>`. Then, in the next operation one must once again narrow down the event type, even though it is clear that it must be of the type that the predicate checks for.

With the change here, an overload of `filter()` is added which also accepts a `TypePredicate`. Then the resulting stream automatically assumes the type that is being checked for - `EventStream<T> -> EventStream<S>`. Care is taken that not only the generic type is changed but that the type of the `Observable` is also preserved (`EventStream` or `Property`)