### PR TITLE
Fix: FlatMap Memory Leak

### DIFF
--- a/src/flatmap_.ts
+++ b/src/flatmap_.ts
@@ -45,9 +45,8 @@ export function flatMap_<In, Out>(spawner: EventSpawner<In, Out>, src: Observabl
       const child = makeObservable<Out>(spawner(event))
       childDeps.push(child)
       return composite.add(function(unsubAll: Unsub, unsubMe: Unsub) {
-        return child.subscribeInternal(function(event: Event<Out>) {
+        const unsub = child.subscribeInternal(function(event: Event<Out>) {
           if (event.isEnd) {
-            _.remove(child, childDeps)
             checkQueue()
             checkEnd(unsubMe)
             return noMore
@@ -58,6 +57,10 @@ export function flatMap_<In, Out>(spawner: EventSpawner<In, Out>, src: Observabl
             return reply
           }
         })
+        return () => {
+          _.remove(child, childDeps)
+          unsub()
+        }
       })
     }
     function checkQueue(): void {


### PR DESCRIPTION
I stumbled upon this when Node.js crashed after running out of heap memory. I had a `Bus.flatMap` stream which was intensively and repeatedly being subscribed and unsubscribed to. Currently, the `childDeps` are being removed from _only_ when the child stream emits an `<end>`. However, when the last subscriber to the root `flatMap` stream unsubscribes, the `CompositeUnsubscribe.unsubscribe()` is called directly. This properly unsubscribes all flat mapped children but they remain in the `childDeps` array.

The solution was to simply wrap the child unsub function, such that it always cleans the `childDeps`, whether it is called because of a child `<end>` or `unsubAll`.