### PR TITLE
TypePredicate filter: better overload matching

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -334,7 +334,7 @@ Same as filtering with a function that always returns false.
     return this.filter(x => false).withDesc(new Desc(this, "errors"))
   }
 
-  filter<S extends V>(f: TypePredicate<S>):  ObservableWithParam<this, S>
+  filter<S extends V>(f: TypePredicate<V, S>):  ObservableWithParam<this, S>
   filter(f: Predicate<V> | boolean | Property<boolean>): this
   /**
 Filters values using given predicate function.

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,4 +24,4 @@ export type Function4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4) => R
 export type Function5<T1, T2, T3, T4, T5, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => R;
 export type Function6<T1, T2, T3, T4, T5, T6, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => R;
 export type ObservableWithParam<T extends Observable<any>, P> = T extends Bus<any>|EventStream<any> ? EventStream<P> : T extends Property<any> ? Property<P> : Observable<P>
-export type TypePredicate<S> = (v: any) => v is S
+export type TypePredicate<V, S extends V> = (v: V) => v is S


### PR DESCRIPTION
It turns out that when the type predicate takes `any` argument, TypeScript does not always select the proper `filter()` overload. Now the `TypePredicate` type takes also the original type `V` and the checked-for type `S extends V`. This seems to solve the problems.